### PR TITLE
Fix dispatch accessibility

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,6 +37,7 @@ pub use self::component::*;
 use self::default_components::*;
 pub use self::lifecycle::*;
 pub use self::ports::*;
+pub use self::dispatch::*;
 pub use self::runtime::*;
 pub use self::serialisation::*;
 pub use self::timer_manager::*;


### PR DESCRIPTION
Although i'm not certain that everything in the dispatch module should be accessible, I had to do this in order to access NetworkConfig and NetworkDispatcher for a simple actor setup.

https://github.com/Max-Meldrum/KompactExecutor/blob/master/src/main.rs