### PR TITLE
Serialiser trait update

### DIFF
--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -820,6 +820,7 @@ mod dispatch_tests {
         i: u64,
     }
 
+    #[derive(Clone)]
     struct PingPongSer;
     impl PingPongSer {
         const SID: SerId = 42;

--- a/core/src/messaging/mod.rs
+++ b/core/src/messaging/mod.rs
@@ -536,6 +536,7 @@ mod deser_macro_tests {
             MsgB { flag }
         }
     }
+    #[derive(Clone)]
     struct BSer;
     impl Serialiser<MsgB> for BSer {
         fn ser_id(&self) -> SerId {

--- a/core/src/serialisation/core.rs
+++ b/core/src/serialisation/core.rs
@@ -7,7 +7,7 @@ pub enum SerError {
     Unknown(String),
 }
 
-pub trait Serialiser<T>: Send {
+pub trait Serialiser<T>: Send + Sync + Clone {
     fn ser_id(&self) -> SerId;
     fn size_hint(&self) -> Option<usize> {
         None

--- a/core/src/serialisation/mod.rs
+++ b/core/src/serialisation/mod.rs
@@ -79,6 +79,7 @@ mod tests {
         i: u64,
     }
 
+    #[derive(Clone)]
     struct T1Ser;
     impl Serialiser<Test1> for T1Ser {
         fn ser_id(&self) -> SerId {

--- a/core/src/serialisation/protobuf_serialisers.rs
+++ b/core/src/serialisation/protobuf_serialisers.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use protobuf::{Message, ProtobufError};
 
+#[derive(Clone)]
 pub struct ProtobufSer;
 
 impl<M: Message + Any + Debug> Serialiser<M> for ProtobufSer {

--- a/experiments/dynamic-benches/src/actorrefs.rs
+++ b/experiments/dynamic-benches/src/actorrefs.rs
@@ -54,6 +54,7 @@ impl Actor for TestActor {
     }
 }
 
+#[derive(Clone)]
 pub struct PingSer;
 pub const PING_SER: PingSer = PingSer {};
 impl Serialiser<Ping> for PingSer {


### PR DESCRIPTION
Would need this change for handling different serialisers during runtime. See [here](https://github.com/Max-Meldrum/arcon/blob/6490a1cc84770a37d90705fdb4123f3ceb983969/execution-plane/arcon/src/data/serde.rs#L4) and [here](https://github.com/Max-Meldrum/arcon/blob/6490a1cc84770a37d90705fdb4123f3ceb983969/execution-plane/arcon/src/streaming/channel/mod.rs#L9)

But this would most likely break your benchmarks, that is, your serialiser structs need to derive clone. I could continue to use my own branch rather than master if you wanna avoid potential issues.