### PR TITLE
Type-erased component definitions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ ser_id_16 = []
 ser_id_8 = []
 thread_pinning = ["core_affinity", "executors/thread-pinning"]
 serde_support = ["serde", "bytes/serde"]
+type_erasure = []
 
 [dependencies]
 log = "0.4"

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -177,7 +177,7 @@ pub trait DynActorRefFactory {
 
 impl<F> DynActorRefFactory for F
 where
-    F: ActorRefFactory,
+    F: ActorRefFactory + ?Sized,
 {
     fn dyn_ref(&self) -> DynActorRef {
         self.actor_ref().dyn_ref()

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -374,6 +374,17 @@ where
     }
 }
 
+impl<CD> ActorRefFactory for Component<CD>
+where
+    CD: ComponentDefinition + ActorRaw + 'static,
+{
+    type Message = CD::Message;
+
+    fn actor_ref(&self) -> ActorRef<CD::Message> {
+        self.on_definition(|c| c.ctx().actor_ref())
+    }
+}
+
 impl<CD> Dispatching for CD
 where
     CD: ComponentDefinition + 'static,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,6 +41,7 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::match_ref_pats)]
 #![cfg_attr(nightly, feature(never_type))]
+#![cfg_attr(all(nightly, feature = "type_erasure"), feature(unsized_locals))]
 
 #[cfg(feature = "thread_pinning")]
 pub use core_affinity::{get_core_ids, CoreId};
@@ -207,6 +208,11 @@ pub mod prelude {
             PromiseErr,
             TryDualLockError,
         },
+    };
+
+    #[cfg(all(nightly, feature = "type_erasure"))]
+    pub use crate::{
+        utils::erased::ErasedActorDefinition
     };
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -211,9 +211,7 @@ pub mod prelude {
     };
 
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub use crate::{
-        utils::erased::ErasedActorDefinition
-    };
+    pub use crate::utils::erased::ErasedComponentDefinition;
 }
 
 /// A module containing helper functions for (unit) testing

--- a/core/src/messaging/mod.rs
+++ b/core/src/messaging/mod.rs
@@ -596,7 +596,7 @@ pub struct RegistrationEnvelope {
 impl RegistrationEnvelope {
     /// Create a registration envelope without a promise for feedback
     pub fn basic(
-        actor: &dyn DynActorRefFactory,
+        actor: &(impl DynActorRefFactory + ?Sized),
         path: PathResolvable,
         update: bool,
     ) -> RegistrationEnvelope {
@@ -610,7 +610,7 @@ impl RegistrationEnvelope {
 
     /// Create a registration envelope using a promise for feedback
     pub fn with_promise(
-        actor: &dyn DynActorRefFactory,
+        actor: &(impl DynActorRefFactory + ?Sized),
         path: PathResolvable,
         update: bool,
         promise: utils::Promise<RegistrationResult>,
@@ -625,7 +625,7 @@ impl RegistrationEnvelope {
 
     /// Create a registration envelope using an actor reference for feedback
     pub fn with_recipient(
-        actor: &dyn DynActorRefFactory,
+        actor: &(impl DynActorRefFactory + ?Sized),
         path: PathResolvable,
         update: bool,
         id: RegistrationId,

--- a/core/src/runtime/system.rs
+++ b/core/src/runtime/system.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(all(nightly, feature = "type_erasure"))]
-use crate::utils::erased::{ErasedComponent, ErasedComponentDefinition};
+use crate::utils::erased::ErasedComponentDefinition;
 use crate::{
     messaging::{
         DispatchEnvelope,
@@ -209,9 +209,11 @@ impl KompactSystem {
     /// is internally wrapped into an [Arc](std::sync::Arc).
     ///
     /// Newly created components are not started automatically.
-    /// Use [start_erased](KompactSystem::start) or
-    /// [start_erased_notify](KompactSystem::start_notify) to start a newly
+    /// Use [start](KompactSystem::start) or
+    /// [start_notify](KompactSystem::start_notify) to start a newly
     /// created component, once it is connected properly.
+    ///
+    /// If you need address this component via the network, see the [register](KompactSystem::register) function.
     ///
     /// # Example
     ///
@@ -227,7 +229,7 @@ impl KompactSystem {
     pub fn create_erased<M: MessageBounds>(
         &self,
         a: Box<dyn ErasedComponentDefinition<M>>,
-    ) -> Arc<dyn ErasedComponent<Message = M>> {
+    ) -> Arc<dyn AbstractComponent<Message = M>> {
         a.spawn_on(self)
     }
 
@@ -422,14 +424,11 @@ impl KompactSystem {
     /// system.register(&c).wait_expect(Duration::from_millis(1000), "Failed to register TestComponent1");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn register<C>(&self, c: &Arc<Component<C>>) -> Future<RegistrationResult>
-    where
-        C: ComponentDefinition + 'static,
-    {
+    pub fn register(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> Future<RegistrationResult> {
         self.inner.assert_active();
         let id = c.core().id().clone();
         let id_path = PathResolvable::ActorId(id);
-        self.inner.register_by_path(c, false, id_path) // never update unique registrations
+        self.inner.register_by_path(c.as_ref(), false, id_path) // never update unique registrations
     }
 
     /// Creates a new component and registers it with the dispatcher
@@ -499,17 +498,17 @@ impl KompactSystem {
     /// alias_registration_future.wait_expect(Duration::from_millis(1000), "Failed to register TestComponent1 by alias");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn register_by_alias<C, A>(
+    pub fn register_by_alias<A>(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         alias: A,
     ) -> Future<RegistrationResult>
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>,
     {
         self.inner.assert_active();
-        self.inner.register_by_alias(c, false, alias.into())
+        self.inner
+            .register_by_alias(c.as_ref(), false, alias.into())
     }
 
     /// Attempts to register the provided component with a human-readable alias.
@@ -546,17 +545,16 @@ impl KompactSystem {
     /// alias_reregistration_future.wait_expect(Duration::from_millis(1000), "Failed to override TestComponent1 registration by alias");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn update_alias_registration<C, A>(
+    pub fn update_alias_registration<A>(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         alias: A,
     ) -> Future<RegistrationResult>
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>,
     {
         self.inner.assert_active();
-        self.inner.register_by_alias(c, true, alias.into())
+        self.inner.register_by_alias(c.as_ref(), true, alias.into())
     }
 
     /// Start a component
@@ -576,20 +574,7 @@ impl KompactSystem {
     /// system.start(&c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn start<C>(&self, c: &Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_not_poisoned();
-        c.enqueue_control(ControlEvent::Start);
-    }
-
-    /// Like [start](KompactSystem::start), but for [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn start_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
-    where
-        M: MessageBounds,
-    {
+    pub fn start(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> () {
         self.inner.assert_not_poisoned();
         c.enqueue_control(ControlEvent::Start);
     }
@@ -618,28 +603,7 @@ impl KompactSystem {
     ///       .expect("TestComponent1 never started!");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn start_notify<C>(&self, c: &Arc<Component<C>>) -> Future<()>
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_active();
-        let (p, f) = utils::promise();
-        let amp = Arc::new(Mutex::new(p));
-        self.supervision_port().enqueue(SupervisorMsg::Listen(
-            amp,
-            ListenEvent::Started(c.id().clone()),
-        ));
-        c.enqueue_control(ControlEvent::Start);
-        f
-    }
-
-    /// Like [start_notify](KompactSystem::start_notify), but for
-    /// [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn start_erased_notify<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
-    where
-        M: MessageBounds,
-    {
+    pub fn start_notify(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> Future<()> {
         self.inner.assert_active();
         let (p, f) = utils::promise();
         let amp = Arc::new(Mutex::new(p));
@@ -675,20 +639,7 @@ impl KompactSystem {
     /// system.stop(&c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn stop<C>(&self, c: &Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_active();
-        c.enqueue_control(ControlEvent::Stop);
-    }
-
-    /// Like [stop](KompactSystem::stop), but for [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn stop_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
-    where
-        M: MessageBounds,
-    {
+    pub fn stop(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> () {
         self.inner.assert_active();
         c.enqueue_control(ControlEvent::Stop);
     }
@@ -726,27 +677,7 @@ impl KompactSystem {
     ///       .expect("TestComponent1 never re-started!");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn stop_notify<C>(&self, c: &Arc<Component<C>>) -> Future<()>
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_active();
-        let (p, f) = utils::promise();
-        let amp = Arc::new(Mutex::new(p));
-        self.supervision_port().enqueue(SupervisorMsg::Listen(
-            amp,
-            ListenEvent::Stopped(c.id().clone()),
-        ));
-        c.enqueue_control(ControlEvent::Stop);
-        f
-    }
-
-    /// Like [stop_notify](KompactSystem::stop_notify), but for [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn stop_erased_notify<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
-    where
-        M: MessageBounds,
-    {
+    pub fn stop_notify(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> Future<()> {
         self.inner.assert_active();
         let (p, f) = utils::promise();
         let amp = Arc::new(Mutex::new(p));
@@ -779,20 +710,7 @@ impl KompactSystem {
     /// system.kill(c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn kill<C>(&self, c: Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_active();
-        c.enqueue_control(ControlEvent::Kill);
-    }
-
-    /// Like [kill](KompactSystem::kill), but for [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn kill_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
-    where
-        M: MessageBounds,
-    {
+    pub fn kill(&self, c: Arc<impl AbstractComponent + ?Sized>) -> () {
         self.inner.assert_active();
         c.enqueue_control(ControlEvent::Kill);
     }
@@ -829,27 +747,7 @@ impl KompactSystem {
     ///       .expect("TestComponent1 never stopped!");
     /// # system.shutdown().expect("shutdown");
     /// ```
-    pub fn kill_notify<C>(&self, c: Arc<Component<C>>) -> Future<()>
-    where
-        C: ComponentDefinition + 'static,
-    {
-        self.inner.assert_active();
-        let (p, f) = utils::promise();
-        let amp = Arc::new(Mutex::new(p));
-        self.supervision_port().enqueue(SupervisorMsg::Listen(
-            amp,
-            ListenEvent::Destroyed(c.id().clone()),
-        ));
-        c.enqueue_control(ControlEvent::Kill);
-        f
-    }
-
-    /// Like [kill_notify](KompactSystem::kill_notify), but for [ErasedComponent](ErasedComponent)s.
-    #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn kill_erased_notify<M>(&self, c: Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
-    where
-        M: MessageBounds,
-    {
+    pub fn kill_notify(&self, c: Arc<impl AbstractComponent + ?Sized>) -> Future<()> {
         self.inner.assert_active();
         let (p, f) = utils::promise();
         let amp = Arc::new(Mutex::new(p));
@@ -1013,10 +911,7 @@ impl KompactSystem {
     /// a perfectly valid `ActorPath` instance, but which can not receive any messages,
     /// unless you also registered the component with this system's dispatcher.
     /// Suffice to say, crossing system boundaries in this manner is not recommended.
-    pub fn actor_path_for<C>(&self, component: &Arc<Component<C>>) -> ActorPath
-    where
-        C: ComponentDefinition + 'static,
-    {
+    pub fn actor_path_for(&self, component: &Arc<impl AbstractComponent + ?Sized>) -> ActorPath {
         let id = *component.id();
         ActorPath::Unique(UniquePath::with_system(self.system_path(), id))
     }
@@ -1090,6 +985,33 @@ pub trait SystemHandle: Dispatching {
     where
         F: FnOnce() -> C,
         C: ComponentDefinition + 'static;
+
+    /// Create a new component from type-erased definition
+    ///
+    /// Since components are shared between threads, the created component
+    /// is internally wrapped into an [Arc](std::sync::Arc).
+    ///
+    /// Newly created components are not started automatically.
+    /// Use [start](KompactSystem::start) or
+    /// [start_notify](KompactSystem::start_notify) to start a newly
+    /// created component, once it is connected properly.
+    ///
+    /// If you need address this component via the network, see the [register](KompactSystem::register) function.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use kompact::prelude::*;
+    /// # use kompact::doctest_helpers::*;
+    /// # let system = KompactConfig::default().build().expect("system");
+    /// let c = system.create_erased(Box::new(TestComponent1::new()));
+    /// # system.shutdown().expect("shutdown");
+    /// ```
+    #[cfg(all(nightly, feature = "type_erasure"))]
+    fn create_erased<M: MessageBounds>(
+        &self,
+        a: Box<dyn ErasedComponentDefinition<M>>,
+    ) -> Arc<dyn AbstractComponent<Message = M>>;
 
     /// Attempts to register `c` with the dispatcher using its unique id
     ///
@@ -1165,20 +1087,16 @@ pub trait SystemHandle: Dispatching {
     /// # std::thread::sleep(Duration::from_millis(1000));
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn register<C>(
+    fn register(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         reply_to: &dyn Receiver<RegistrationResponse>,
-    ) -> RegistrationId
-    where
-        C: ComponentDefinition + 'static;
+    ) -> RegistrationId;
 
     /// Attempts to register `c` with the dispatcher using its unique id
     ///
     /// Same as [register](SystemHandle::register) except requesting that no response be send.
-    fn register_without_response<C>(&self, c: &Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static;
+    fn register_without_response(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> ();
 
     /// Attempts to register the provided component with a human-readable alias
     ///
@@ -1261,22 +1179,24 @@ pub trait SystemHandle: Dispatching {
     /// # std::thread::sleep(Duration::from_millis(1000));
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn register_by_alias<C, A>(
+    fn register_by_alias<A>(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         alias: A,
         reply_to: &dyn Receiver<RegistrationResponse>,
     ) -> RegistrationId
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>;
 
     /// Attempts to register the provided component with a human-readable alias
     ///
     /// Same as [register_by_alias](SystemHandle::register_by_alias) except requesting that no response be send.
-    fn register_by_alias_without_response<C, A>(&self, c: &Arc<Component<C>>, alias: A) -> ()
+    fn register_by_alias_without_response<A>(
+        &self,
+        c: &Arc<impl AbstractComponent + ?Sized>,
+        alias: A,
+    ) -> ()
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>;
 
     /// Attempts to register the provided component with a human-readable alias.
@@ -1359,26 +1279,24 @@ pub trait SystemHandle: Dispatching {
     /// # std::thread::sleep(Duration::from_millis(1000));
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn update_alias_registration<C, A>(
+    fn update_alias_registration<A>(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         alias: A,
         reply_to: &dyn Receiver<RegistrationResponse>,
     ) -> RegistrationId
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>;
 
     /// Attempts to register the provided component with a human-readable alias
     ///
     /// Same as [update_alias_registration](SystemHandle::update_alias_registration) except requesting that no response be send.
-    fn update_alias_registration_without_response<C, A>(
+    fn update_alias_registration_without_response<A>(
         &self,
-        c: &Arc<Component<C>>,
+        c: &Arc<impl AbstractComponent + ?Sized>,
         alias: A,
     ) -> ()
     where
-        C: ComponentDefinition + 'static,
         A: Into<String>;
 
     /// Start a component
@@ -1398,9 +1316,7 @@ pub trait SystemHandle: Dispatching {
     /// system.start(&c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn start<C>(&self, c: &Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static;
+    fn start(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> ();
 
     /// Stop a component
     ///
@@ -1426,9 +1342,7 @@ pub trait SystemHandle: Dispatching {
     /// system.stop(&c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn stop<C>(&self, c: &Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static;
+    fn stop(&self, c: &Arc<impl AbstractComponent + ?Sized>) -> ();
 
     /// Stop and deallocate a component
     ///
@@ -1451,9 +1365,7 @@ pub trait SystemHandle: Dispatching {
     /// system.kill(c);
     /// # system.shutdown().expect("shutdown");
     /// ```
-    fn kill<C>(&self, c: Arc<Component<C>>) -> ()
-    where
-        C: ComponentDefinition + 'static;
+    fn kill(&self, c: Arc<impl AbstractComponent + ?Sized>) -> ();
 
     /// Return the configured thoughput value
     ///
@@ -1643,7 +1555,7 @@ impl KompactRuntime {
         path: PathResolvable,
     ) -> Future<RegistrationResult>
     where
-        D: DynActorRefFactory,
+        D: DynActorRefFactory + ?Sized,
     {
         debug!(self.logger(), "Requesting actor registration at {:?}", path);
         let (promise, future) = utils::promise();
@@ -1663,7 +1575,7 @@ impl KompactRuntime {
         alias: String,
     ) -> Future<RegistrationResult>
     where
-        D: DynActorRefFactory,
+        D: DynActorRefFactory + ?Sized,
     {
         debug!(
             self.logger(),

--- a/core/src/runtime/system.rs
+++ b/core/src/runtime/system.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(all(nightly, feature = "type_erasure"))]
-use crate::utils::erased::{ErasedActorDefinition, ErasedComponent};
+use crate::utils::erased::{ErasedComponent, ErasedComponentDefinition};
 use crate::{
     messaging::{
         DispatchEnvelope,
@@ -226,7 +226,7 @@ impl KompactSystem {
     #[inline(always)]
     pub fn create_erased<M: MessageBounds>(
         &self,
-        a: Box<dyn ErasedActorDefinition<M>>,
+        a: Box<dyn ErasedComponentDefinition<M>>,
     ) -> Arc<dyn ErasedComponent<Message = M>> {
         a.spawn_on(self)
     }

--- a/core/src/runtime/system.rs
+++ b/core/src/runtime/system.rs
@@ -645,7 +645,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Started(c.comp_id().clone()),
+            ListenEvent::Started(c.id().clone()),
         ));
         c.enqueue_control(ControlEvent::Start);
         f
@@ -752,7 +752,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Stopped(c.comp_id().clone()),
+            ListenEvent::Stopped(c.id().clone()),
         ));
         c.enqueue_control(ControlEvent::Stop);
         f
@@ -855,7 +855,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Destroyed(c.comp_id().clone()),
+            ListenEvent::Destroyed(c.id().clone()),
         ));
         c.enqueue_control(ControlEvent::Kill);
         f

--- a/core/src/runtime/system.rs
+++ b/core/src/runtime/system.rs
@@ -227,7 +227,7 @@ impl KompactSystem {
     pub fn create_erased<M: MessageBounds>(
         &self,
         a: Box<dyn ErasedActorDefinition<M>>,
-    ) -> ErasedComponent<M> {
+    ) -> Arc<dyn ErasedComponent<Message = M>> {
         a.spawn_on(self)
     }
 
@@ -586,7 +586,7 @@ impl KompactSystem {
 
     /// Like [start](KompactSystem::start), but for [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn start_erased<M>(&self, c: &ErasedComponent<M>) -> ()
+    pub fn start_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
     where
         M: MessageBounds,
     {
@@ -636,7 +636,7 @@ impl KompactSystem {
     /// Like [start_notify](KompactSystem::start_notify), but for
     /// [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn start_erased_notify<M>(&self, c: &ErasedComponent<M>) -> Future<()>
+    pub fn start_erased_notify<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
     where
         M: MessageBounds,
     {
@@ -645,7 +645,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Started(c.id().clone()),
+            ListenEvent::Started(c.comp_id().clone()),
         ));
         c.enqueue_control(ControlEvent::Start);
         f
@@ -685,7 +685,7 @@ impl KompactSystem {
 
     /// Like [stop](KompactSystem::stop), but for [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn stop_erased<M>(&self, c: &ErasedComponent<M>) -> ()
+    pub fn stop_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
     where
         M: MessageBounds,
     {
@@ -743,7 +743,7 @@ impl KompactSystem {
 
     /// Like [stop_notify](KompactSystem::stop_notify), but for [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn stop_erased_notify<M>(&self, c: &ErasedComponent<M>) -> Future<()>
+    pub fn stop_erased_notify<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
     where
         M: MessageBounds,
     {
@@ -752,7 +752,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Stopped(c.id().clone()),
+            ListenEvent::Stopped(c.comp_id().clone()),
         ));
         c.enqueue_control(ControlEvent::Stop);
         f
@@ -789,7 +789,7 @@ impl KompactSystem {
 
     /// Like [kill](KompactSystem::kill), but for [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn kill_erased<M>(&self, c: ErasedComponent<M>) -> ()
+    pub fn kill_erased<M>(&self, c: &Arc<dyn ErasedComponent<Message = M>>) -> ()
     where
         M: MessageBounds,
     {
@@ -846,7 +846,7 @@ impl KompactSystem {
 
     /// Like [kill_notify](KompactSystem::kill_notify), but for [ErasedComponent](ErasedComponent)s.
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub fn kill_erased_notify<M>(&self, c: ErasedComponent<M>) -> Future<()>
+    pub fn kill_erased_notify<M>(&self, c: Arc<dyn ErasedComponent<Message = M>>) -> Future<()>
     where
         M: MessageBounds,
     {
@@ -855,7 +855,7 @@ impl KompactSystem {
         let amp = Arc::new(Mutex::new(p));
         self.supervision_port().enqueue(SupervisorMsg::Listen(
             amp,
-            ListenEvent::Destroyed(c.id().clone()),
+            ListenEvent::Destroyed(c.comp_id().clone()),
         ));
         c.enqueue_control(ControlEvent::Kill);
         f

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -362,8 +362,7 @@ pub mod erased {
     use uuid::Uuid;
 
     /// Trait representing a type-erased component.
-    pub trait ErasedComponent: ActorRefFactory + Any {
-        fn comp_id(&self) -> &Uuid;
+    pub trait ErasedComponent: ActorRefFactory + CoreContainer + Any {
         fn enqueue_control(&self, event: <ControlPort as Port>::Request);
         fn as_any(&self) -> &dyn Any;
     }
@@ -372,10 +371,6 @@ pub mod erased {
     where
         C: ComponentDefinition,
     {
-        fn comp_id(&self) -> &Uuid {
-            CoreContainer::id(self)
-        }
-
         fn enqueue_control(&self, event: <ControlPort as Port>::Request) {
             Component::enqueue_control(self, event)
         }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -354,16 +354,14 @@ pub mod erased {
     use crate::{
         actors::{ActorRefFactory, MessageBounds},
         component::{Component, ComponentDefinition, CoreContainer},
-        lifecycle::ControlPort,
-        ports::Port,
+        lifecycle::ControlEvent,
         runtime::KompactSystem,
     };
     use std::{any::Any, sync::Arc};
-    use uuid::Uuid;
 
     /// Trait representing a type-erased component.
     pub trait ErasedComponent: ActorRefFactory + CoreContainer + Any {
-        fn enqueue_control(&self, event: <ControlPort as Port>::Request);
+        fn enqueue_control(&self, event: ControlEvent);
         fn as_any(&self) -> &dyn Any;
     }
 
@@ -371,7 +369,7 @@ pub mod erased {
     where
         C: ComponentDefinition,
     {
-        fn enqueue_control(&self, event: <ControlPort as Port>::Request) {
+        fn enqueue_control(&self, event: ControlEvent) {
             Component::enqueue_control(self, event)
         }
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -390,13 +390,13 @@ pub mod erased {
     /// Should not be implemented manually.
     ///
     /// See: [KompactSystem::create_erased](KompactSystem::create_erased)
-    pub trait ErasedActorDefinition<M: MessageBounds> {
+    pub trait ErasedComponentDefinition<M: MessageBounds> {
         // this is only object-safe with unsized_locals nightly feature
         /// Creates component on the given system.
         fn spawn_on(self, system: &KompactSystem) -> Arc<dyn ErasedComponent<Message = M>>;
     }
 
-    impl<M, C> ErasedActorDefinition<M> for C
+    impl<M, C> ErasedComponentDefinition<M> for C
     where
         M: MessageBounds,
         C: ComponentDefinition<Message = M> + 'static,
@@ -485,11 +485,11 @@ mod tests {
     #[cfg(all(nightly, feature = "type_erasure"))]
     #[test]
     fn test_erased_components() {
-        use utils::erased::ErasedActorDefinition;
+        use utils::erased::ErasedComponentDefinition;
         let system = KompactConfig::default().build().expect("System");
 
         {
-            let erased_definition: Box<dyn ErasedActorDefinition<Ask<u64, ()>>> =
+            let erased_definition: Box<dyn ErasedComponentDefinition<Ask<u64, ()>>> =
                 Box::new(TestComponent::new());
             let erased = system.create_erased(erased_definition);
             let actor_ref = erased.actor_ref();


### PR DESCRIPTION
This adds the ability to create components from trait objects in the form of `Box<dyn ErasedComponentDefinition<Message=M>>`. It can be useful if you want to have some runtime logic deciding what component to create.

Most of the actual implementation is in `utils::erased`. The main thing is the `ErasedComponentDefinition` trait, which is only useful if `unsized_locals` nightly feature is turned on.

 The `ErasedComponent` trait could actually be extracted outside this module and renamed (`ComponentInterface`?), because it's just an amalgamation of a few other object safe traits that every component implements + `enqueue_control` method. We could probably remove most of the `_erased` versions of the `KompactSystem` methods if that was the case because we could use that trait for both the concrete components and type-erased components.