### PR TITLE
Dynamic port access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "oncemutex",
+ "owning_ref",
  "protobuf",
  "rustc_version",
  "sequence_trie",
@@ -827,6 +828,15 @@ name = "oorandom"
 version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
+
+[[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "panoradix"
@@ -1191,6 +1201,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "syn"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,6 +57,7 @@ fxhash = "0.2.1"
 fnv = "1.0"
 hocon = {version = "0.3", default-features = false}
 hierarchical_hash_wheel_timer = "1.0"
+owning_ref = "0.4.1"
 
 # Optional
 protobuf = {version = "2", optional = true, features = ["with-bytes"]}

--- a/core/src/bin/pingperf.rs
+++ b/core/src/bin/pingperf.rs
@@ -27,7 +27,7 @@ impl Port for PingPongPort {
 #[derive(ComponentDefinition, Actor)]
 struct Pinger {
     ctx: ComponentContext<Pinger>,
-    ppp: RequiredPort<PingPongPort, Pinger>,
+    ppp: RequiredPort<PingPongPort>,
     latch: Arc<CountdownEvent>,
     repeat: u64,
     sent: u64,
@@ -81,7 +81,7 @@ impl Require<PingPongPort> for Pinger {
 #[derive(ComponentDefinition, Actor)]
 struct Ponger {
     ctx: ComponentContext<Ponger>,
-    ppp: ProvidedPort<PingPongPort, Ponger>,
+    ppp: ProvidedPort<PingPongPort>,
     received: u64,
 }
 

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -1601,10 +1601,8 @@ mod tests {
             }
         }
         ignore_control!(TestComp);
-        ignore_requests!(A, TestComp);
         ignore_requests!(B, TestComp);
         ignore_indications!(A, TestComp);
-        ignore_indications!(B, TestComp);
 
         let system = KompactConfig::default().build().expect("System");
         let comp = system.create(|| TestComp::new());

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -32,7 +32,8 @@ use crate::{
 
 use crate::net::buffer::EncodeBuffer;
 #[cfg(all(nightly, feature = "type_erasure"))]
-use crate::utils::erased::ErasedComponentDefinition;
+use crate::utils::erased::CreateErased;
+use owning_ref::{Erased, OwningRefMut};
 use std::any::Any;
 
 /// A trait for abstracting over structures that contain a component core
@@ -792,7 +793,7 @@ impl SystemHandle for ContextSystemHandle {
     #[cfg(all(nightly, feature = "type_erasure"))]
     fn create_erased<M: MessageBounds>(
         &self,
-        a: Box<dyn ErasedComponentDefinition<M>>,
+        a: Box<dyn CreateErased<M>>,
     ) -> Arc<dyn AbstractComponent<Message = M>> {
         self.component.system().create_erased(a)
     }
@@ -929,6 +930,20 @@ impl Dispatching for ContextSystemHandle {
     }
 }
 
+/// Object-safe part of [`ComponentDefinition`].
+///
+/// This trait aggregates all the object-safe super-traits of [`ComponentDefinition`] to make
+/// trait objects possible while rust doesn't have multi-trait trait-objects.
+pub trait DynamicComponentDefinition:
+    DynamicPortAccess + Provide<ControlPort> + ActorRaw + Send
+{
+}
+
+impl<T> DynamicComponentDefinition for T where
+    T: DynamicPortAccess + Provide<ControlPort> + ActorRaw + Send
+{
+}
+
 /// The core trait every component must implement
 ///
 /// Should usually simply be derived using `#[derive(ComponentDefinition)]`.
@@ -942,7 +957,7 @@ impl Dispatching for ContextSystemHandle {
 /// [ProvideRef](ProvideRef) or [RequireRef](RequireRef) for each of the
 /// component's ports. It is generally recommended to do so as well, when not
 /// using the derive macro, as it enables some rather convenient APIs.
-pub trait ComponentDefinition: Provide<ControlPort> + ActorRaw + Send
+pub trait ComponentDefinition: DynamicComponentDefinition
 where
     Self: Sized,
 {
@@ -978,6 +993,59 @@ where
     fn type_name() -> &'static str;
 }
 
+/// A mechanism for dynamically getting references to provided/required ports from a component.
+///
+/// Should only be used if working with concrete types, or strict generic bounds (i.e. [`Provide`],
+/// [`ProvideRef`], etc.) is not an option. This is the case, for example, when working with
+/// `Arc<dyn `[`AbstractComponent`]`>`.
+pub trait DynamicPortAccess {
+    /// **Internal API**. Dynamically obtain a mutable reference to a [`ProvidedPort`] if `self`
+    /// provides a port of the type indicated by the passed `port_id`.
+    ///
+    /// This is a low-level API that is automatically implemented by
+    /// `#[derive(ComponentDefinition)]`. Prefer the more strongly typed
+    /// [`get_provided_port`](trait.DynamicComponentDefinition.html#method.get_provided_port).
+    fn get_provided_port_as_any(&mut self, port_id: std::any::TypeId) -> Option<&mut dyn Any>;
+
+    /// **Internal API**. Dynamically obtain a mutable reference to a [`RequiredPort`] if `self`
+    /// requires a port of the type indicated by the passed `port_id`.
+    ///
+    /// This is a low-level API that is automatically implemented by
+    /// `#[derive(ComponentDefinition)]`. Prefer the more strongly typed
+    /// [`get_required_port`](trait.DynamicComponentDefinition.html#method.get_required_port).
+    fn get_required_port_as_any(&mut self, port_id: std::any::TypeId) -> Option<&mut dyn Any>;
+}
+
+impl<'a, M: MessageBounds> dyn DynamicComponentDefinition<Message = M> + 'a {
+    /// Dynamically obtain a mutable reference to a [`ProvidedPort<P>`](ProvidedPort) if `self`
+    /// provides a port of type `P`.
+    pub fn get_provided_port<P: Port>(&mut self) -> Option<&mut ProvidedPort<P>> {
+        self.get_provided_port_as_any(std::any::TypeId::of::<P>())
+            .and_then(|any| any.downcast_mut())
+    }
+
+    /// Dynamically obtain a mutable reference to a [`RequiredPort<P>`](RequiredPort) if `self`
+    /// requires a port of type `P`.
+    pub fn get_required_port<P: Port>(&mut self) -> Option<&mut RequiredPort<P>> {
+        self.get_required_port_as_any(std::any::TypeId::of::<P>())
+            .and_then(|any| any.downcast_mut())
+    }
+}
+
+/// Mutex guard guarding a [`DynamicComponentDefinition`] trait object.
+pub type DynamicComponentDefinitionMutexGuard<'a, M> =
+    OwningRefMut<Box<dyn Erased + 'a>, dyn DynamicComponentDefinition<Message = M>>;
+
+/// Error for when the component definition lock has been poisoned
+#[derive(Debug)]
+pub struct LockPoisoned;
+impl fmt::Display for LockPoisoned {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "component definition lock has been poisoned")
+    }
+}
+impl std::error::Error for LockPoisoned {}
+
 /// An object-safe trait that exposes most of functionality of a [`Component`] that isn't
 /// dependent on a particular [`ComponentDefinition`].
 ///
@@ -988,21 +1056,75 @@ pub trait AbstractComponent: ActorRefFactory + CoreContainer + Any {
     #[doc(hidden)] // internal api
     fn enqueue_control(&self, event: ControlEvent);
 
+    /// Returns a mutable reference to the underlying component definition as a
+    /// [`DynamicComponentDefinition`] trait object.
+    ///
+    /// This can only be done if you have a reference to the component instance that isn't hidden
+    /// behind an [Arc](std::sync::Arc). For example, after the system shuts down and your code
+    /// holds on to the last reference to a component you can use [get_mut](std::sync::Arc::get_mut)
+    /// or [try_unwrap](std::sync::Arc::try_unwrap).
+    fn dyn_definition_mut(
+        &mut self,
+    ) -> &mut dyn DynamicComponentDefinition<Message = Self::Message>;
+
+    /// Locks the component definition mutex and returns a guard that can be dereferenced to
+    /// access a [`DynamicComponentDefinition`] trait object.
+    fn lock_dyn_definition(
+        &self,
+    ) -> Result<DynamicComponentDefinitionMutexGuard<Self::Message>, LockPoisoned>;
+
     /// Views self as [`Any`](std::any::Any). Can be used to downcast to a concrete [`Component`].
     fn as_any(&self) -> &dyn Any;
 }
 
 impl<C> AbstractComponent for Component<C>
 where
-    C: ComponentDefinition,
+    C: ComponentDefinition + 'static,
 {
     #[doc(hidden)] // internal api
     fn enqueue_control(&self, event: ControlEvent) {
         Component::enqueue_control(self, event)
     }
 
+    fn dyn_definition_mut(
+        &mut self,
+    ) -> &mut dyn DynamicComponentDefinition<Message = Self::Message> {
+        self.definition_mut()
+    }
+
+    fn lock_dyn_definition(
+        &self,
+    ) -> Result<DynamicComponentDefinitionMutexGuard<Self::Message>, LockPoisoned> {
+        let lock = self.definition.lock().map_err(|_| LockPoisoned)?;
+        let res = OwningRefMut::new(Box::new(lock))
+            .map_mut(|l| {
+                l.deref_mut() as &mut dyn DynamicComponentDefinition<Message = Self::Message>
+            })
+            .erase_owner();
+        Ok(res)
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+impl<M: MessageBounds> dyn AbstractComponent<Message = M> {
+    /// Execute a function on the underlying component definition
+    /// and return the result. The component definition will be accessed as a
+    /// [`DynamicComponentDefinition`] trait object.
+    ///
+    /// This method will attempt to lock the mutex, and then apply `f` to the component definition
+    /// inside the guard.
+    ///
+    /// This method wraps the mutex guard in an additional allocation. Prefer
+    /// [`Component::on_definition`] where possible.
+    pub fn on_dyn_definition<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut dyn DynamicComponentDefinition<Message = M>) -> R,
+    {
+        let mut lock = self.lock_dyn_definition().unwrap();
+        f(&mut *lock)
     }
 }
 
@@ -1210,7 +1332,7 @@ unsafe impl Sync for ComponentCore {}
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
+    use crate::{component::AbstractComponent, prelude::*};
     use std::{sync::Arc, thread, time::Duration};
 
     #[derive(ComponentDefinition, Actor)]
@@ -1446,6 +1568,55 @@ mod tests {
         child.on_definition(|cd| {
             assert!(cd.got_message, "child didn't get the message");
         });
+        system.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn test_dynamic_port_access() -> () {
+        struct A;
+        impl Port for A {
+            type Indication = u64;
+            type Request = String;
+        }
+        struct B;
+        impl Port for B {
+            type Indication = &'static str;
+            type Request = i8;
+        }
+
+        #[derive(ComponentDefinition, Actor)]
+        struct TestComp {
+            ctx: ComponentContext<Self>,
+            req_a: RequiredPort<A>,
+            prov_b: ProvidedPort<B>,
+        }
+
+        impl TestComp {
+            fn new() -> TestComp {
+                TestComp {
+                    ctx: ComponentContext::new(),
+                    req_a: RequiredPort::new(),
+                    prov_b: ProvidedPort::new(),
+                }
+            }
+        }
+        ignore_control!(TestComp);
+        ignore_requests!(A, TestComp);
+        ignore_requests!(B, TestComp);
+        ignore_indications!(A, TestComp);
+        ignore_indications!(B, TestComp);
+
+        let system = KompactConfig::default().build().expect("System");
+        let comp = system.create(|| TestComp::new());
+        let dynamic: Arc<dyn AbstractComponent<Message = Never>> = comp;
+        dynamic.on_dyn_definition(|def| {
+            assert!(def.get_required_port::<A>().is_some());
+            assert!(def.get_provided_port::<A>().is_none());
+
+            assert!(def.get_required_port::<B>().is_none());
+            assert!(def.get_provided_port::<B>().is_some());
+        });
+
         system.shutdown().expect("shutdown");
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -243,7 +243,7 @@ pub mod doctest_helpers {
     #[derive(ComponentDefinition, Actor)]
     pub struct TestComponent1 {
         ctx: ComponentContext<Self>,
-        test_port: ProvidedPort<TestPort, Self>,
+        test_port: ProvidedPort<TestPort>,
     }
 
     impl TestComponent1 {
@@ -266,7 +266,7 @@ pub mod doctest_helpers {
     #[derive(ComponentDefinition, Actor)]
     pub struct TestComponent2 {
         ctx: ComponentContext<Self>,
-        test_port: RequiredPort<TestPort, Self>,
+        test_port: RequiredPort<TestPort>,
     }
 
     impl TestComponent2 {
@@ -370,7 +370,7 @@ mod tests {
     #[derive(ComponentDefinition, Actor)]
     struct TestComponent {
         ctx: ComponentContext<TestComponent>,
-        test_port: ProvidedPort<TestPort, TestComponent>,
+        test_port: ProvidedPort<TestPort>,
         counter: u64,
     }
 
@@ -405,7 +405,7 @@ mod tests {
     #[derive(ComponentDefinition)]
     struct RecvComponent {
         ctx: ComponentContext<RecvComponent>,
-        test_port: RequiredPort<TestPort, RecvComponent>,
+        test_port: RequiredPort<TestPort>,
         last_string: String,
     }
 
@@ -832,7 +832,7 @@ mod tests {
     #[derive(ComponentDefinition)]
     struct CrasherComponent {
         ctx: ComponentContext<CrasherComponent>,
-        crash_port: ProvidedPort<CrashPort, CrasherComponent>,
+        crash_port: ProvidedPort<CrashPort>,
         crash_on_start: bool,
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -160,6 +160,7 @@ pub mod prelude {
             ComponentDefinition,
             ComponentLogging,
             CoreContainer,
+            DynamicPortAccess,
             ExecuteResult,
             LockingProvideRef,
             LockingRequireRef,
@@ -211,7 +212,7 @@ pub mod prelude {
     };
 
     #[cfg(all(nightly, feature = "type_erasure"))]
-    pub use crate::utils::erased::ErasedComponentDefinition;
+    pub use crate::utils::erased::CreateErased;
 }
 
 /// A module containing helper functions for (unit) testing

--- a/core/src/ports.rs
+++ b/core/src/ports.rs
@@ -80,7 +80,7 @@ impl<P: Port + 'static> CommonPortData<P> {
 /// #[derive(ComponentDefinition, Actor)]
 /// struct UnitProvider {
 ///    ctx: ComponentContext<Self>,
-///    unit_port: ProvidedPort<UnitPort, Self>,
+///    unit_port: ProvidedPort<UnitPort>,
 /// }
 /// impl UnitProvider {
 ///     fn new() -> UnitProvider {
@@ -97,15 +97,15 @@ impl<P: Port + 'static> CommonPortData<P> {
 ///     }    
 /// }
 /// ```
-pub struct ProvidedPort<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> {
+pub struct ProvidedPort<P: Port + 'static> {
     common: CommonPortData<P>,
-    parent: Option<Weak<Component<C>>>,
+    parent: Option<Weak<dyn CoreContainer>>,
     msg_queue: Arc<ConcurrentQueue<P::Request>>,
 }
 
-impl<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> ProvidedPort<P, C> {
+impl<P: Port + 'static> ProvidedPort<P> {
     /// Create a new provided port for port type `P` within component `C`
-    pub fn new() -> ProvidedPort<P, C> {
+    pub fn new() -> ProvidedPort<P> {
         ProvidedPort {
             common: CommonPortData::new(),
             parent: None,
@@ -140,7 +140,7 @@ impl<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> ProvidedP
     pub fn share(&mut self) -> ProvidedRef<P> {
         match self.parent {
             Some(ref p) => {
-                let core_container = p.clone() as Weak<dyn CoreContainer>;
+                let core_container = p.clone();
                 ProvidedRef {
                     msg_queue: Arc::downgrade(&self.msg_queue),
                     component: core_container,
@@ -153,7 +153,7 @@ impl<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> ProvidedP
     /// Mark `p` as the parent component of this port
     ///
     /// This method should only be used in custom [ComponentDefinition](ComponentDefinition) implementations!
-    pub fn set_parent(&mut self, p: Arc<Component<C>>) -> () {
+    pub fn set_parent(&mut self, p: Arc<dyn CoreContainer>) -> () {
         self.parent = Some(Arc::downgrade(&p));
     }
 
@@ -185,7 +185,7 @@ impl<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> ProvidedP
 /// #[derive(ComponentDefinition, Actor)]
 /// struct UnitRequirer {
 ///    ctx: ComponentContext<Self>,
-///    unit_port: RequiredPort<UnitPort, Self>,
+///    unit_port: RequiredPort<UnitPort>,
 /// }
 /// impl UnitRequirer {
 ///     fn new() -> UnitRequirer {
@@ -202,15 +202,15 @@ impl<P: Port + 'static, C: ComponentDefinition + Provide<P> + 'static> ProvidedP
 ///     }    
 /// }
 /// ```
-pub struct RequiredPort<P: Port + 'static, C: ComponentDefinition + Require<P> + 'static> {
+pub struct RequiredPort<P: Port + 'static> {
     common: CommonPortData<P>,
-    parent: Option<Weak<Component<C>>>,
+    parent: Option<Weak<dyn CoreContainer>>,
     msg_queue: Arc<ConcurrentQueue<P::Indication>>,
 }
 
-impl<P: Port + 'static, C: ComponentDefinition + Require<P> + 'static> RequiredPort<P, C> {
+impl<P: Port + 'static> RequiredPort<P> {
     /// Create a new required port for port type `P` within component `C`
-    pub fn new() -> RequiredPort<P, C> {
+    pub fn new() -> RequiredPort<P> {
         RequiredPort {
             common: CommonPortData::new(),
             parent: None,
@@ -245,7 +245,7 @@ impl<P: Port + 'static, C: ComponentDefinition + Require<P> + 'static> RequiredP
     pub fn share(&mut self) -> RequiredRef<P> {
         match self.parent {
             Some(ref p) => {
-                let core_container = p.clone() as Weak<dyn CoreContainer>;
+                let core_container = p.clone();
                 RequiredRef {
                     msg_queue: Arc::downgrade(&self.msg_queue),
                     component: core_container,
@@ -258,7 +258,7 @@ impl<P: Port + 'static, C: ComponentDefinition + Require<P> + 'static> RequiredP
     /// Mark `p` as the parent component of this port
     ///
     /// This method should only be used in custom [ComponentDefinition](ComponentDefinition) implementations!
-    pub fn set_parent(&mut self, p: Arc<Component<C>>) -> () {
+    pub fn set_parent(&mut self, p: Arc<dyn CoreContainer>) -> () {
         self.parent = Some(Arc::downgrade(&p));
     }
 

--- a/core/src/runtime/system.rs
+++ b/core/src/runtime/system.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(all(nightly, feature = "type_erasure"))]
-use crate::utils::erased::ErasedComponentDefinition;
+use crate::utils::erased::CreateErased;
 use crate::{
     messaging::{
         DispatchEnvelope,
@@ -228,9 +228,9 @@ impl KompactSystem {
     #[inline(always)]
     pub fn create_erased<M: MessageBounds>(
         &self,
-        a: Box<dyn ErasedComponentDefinition<M>>,
+        a: Box<dyn CreateErased<M>>,
     ) -> Arc<dyn AbstractComponent<Message = M>> {
-        a.spawn_on(self)
+        a.create_in(self)
     }
 
     /// Create a new system component
@@ -986,7 +986,7 @@ pub trait SystemHandle: Dispatching {
         F: FnOnce() -> C,
         C: ComponentDefinition + 'static;
 
-    /// Create a new component from type-erased definition
+    /// Create a new component from type-erased component definition
     ///
     /// Since components are shared between threads, the created component
     /// is internally wrapped into an [Arc](std::sync::Arc).
@@ -1010,7 +1010,7 @@ pub trait SystemHandle: Dispatching {
     #[cfg(all(nightly, feature = "type_erasure"))]
     fn create_erased<M: MessageBounds>(
         &self,
-        a: Box<dyn ErasedComponentDefinition<M>>,
+        a: Box<dyn CreateErased<M>>,
     ) -> Arc<dyn AbstractComponent<Message = M>>;
 
     /// Attempts to register `c` with the dispatcher using its unique id

--- a/core/src/supervision.rs
+++ b/core/src/supervision.rs
@@ -45,7 +45,7 @@ pub(crate) enum SupervisorMsg {
 #[derive(ComponentDefinition, Actor)]
 pub(crate) struct ComponentSupervisor {
     ctx: ComponentContext<ComponentSupervisor>,
-    pub(crate) supervision: ProvidedPort<SupervisionPort, ComponentSupervisor>,
+    pub(crate) supervision: ProvidedPort<SupervisionPort>,
     children: HashMap<Uuid, Arc<dyn CoreContainer>>,
     listeners: HashMap<Uuid, Vec<(ListenEvent, Promise<()>)>>,
     shutdown: Option<Promise<()>>,

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -92,15 +92,7 @@ where
 /// Connect two port instances.
 ///
 /// The providing port instance must be given as first argument, and the requiring instance second.
-pub fn biconnect_ports<P, C1, C2>(
-    prov: &mut ProvidedPort<P, C1>,
-    req: &mut RequiredPort<P, C2>,
-) -> ()
-where
-    P: Port,
-    C1: ComponentDefinition + Sized + 'static + Provide<P>,
-    C2: ComponentDefinition + Sized + 'static + Require<P>,
-{
+pub fn biconnect_ports<P: Port>(prov: &mut ProvidedPort<P>, req: &mut RequiredPort<P>) -> () {
     let prov_share = prov.share();
     let req_share = req.share();
     prov.connect(req_share);

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -350,23 +350,23 @@ pub mod erased {
     };
     use std::sync::Arc;
 
-    /// Trait allowing to create components from type-erased definitions.
+    /// Trait allowing to create components from type-erased component definitions.
     ///
     /// Should not be implemented manually.
     ///
     /// See: [KompactSystem::create_erased](KompactSystem::create_erased)
-    pub trait ErasedComponentDefinition<M: MessageBounds> {
+    pub trait CreateErased<M: MessageBounds> {
         // this is only object-safe with unsized_locals nightly feature
         /// Creates component on the given system.
-        fn spawn_on(self, system: &KompactSystem) -> Arc<dyn AbstractComponent<Message = M>>;
+        fn create_in(self, system: &KompactSystem) -> Arc<dyn AbstractComponent<Message = M>>;
     }
 
-    impl<M, C> ErasedComponentDefinition<M> for C
+    impl<M, C> CreateErased<M> for C
     where
         M: MessageBounds,
         C: ComponentDefinition<Message = M> + 'static,
     {
-        fn spawn_on(self, system: &KompactSystem) -> Arc<dyn AbstractComponent<Message = M>> {
+        fn create_in(self, system: &KompactSystem) -> Arc<dyn AbstractComponent<Message = M>> {
             system.create(|| self)
         }
     }
@@ -450,11 +450,11 @@ mod tests {
     #[cfg(all(nightly, feature = "type_erasure"))]
     #[test]
     fn test_erased_components() {
-        use utils::erased::ErasedComponentDefinition;
+        use utils::erased::CreateErased;
         let system = KompactConfig::default().build().expect("System");
 
         {
-            let erased_definition: Box<dyn ErasedComponentDefinition<Ask<u64, ()>>> =
+            let erased_definition: Box<dyn CreateErased<Ask<u64, ()>>> =
                 Box::new(TestComponent::new());
             let erased = system.create_erased(erased_definition);
             let actor_ref = erased.actor_ref();

--- a/docs/examples/src/batching.rs
+++ b/docs/examples/src/batching.rs
@@ -15,7 +15,7 @@ impl Port for Batching {
 #[derive(ComponentDefinition, Actor)]
 pub struct BatchPrinter {
     ctx: ComponentContext<Self>,
-    batch_port: RequiredPort<Batching, Self>,
+    batch_port: RequiredPort<Batching>,
 }
 impl BatchPrinter {
     pub fn new() -> Self {

--- a/docs/examples/src/bin/bootstrapping.rs
+++ b/docs/examples/src/bin/bootstrapping.rs
@@ -57,7 +57,7 @@ impl NetworkActor for BootstrapServer {
 #[derive(ComponentDefinition)]
 struct EventualLeaderElector {
     ctx: ComponentContext<Self>,
-    omega_port: ProvidedPort<EventualLeaderDetection, Self>,
+    omega_port: ProvidedPort<EventualLeaderDetection>,
     bootstrap_server: ActorPath,
     processes: Box<[ActorPath]>,
     candidates: HashSet<ActorPath>,

--- a/docs/examples/src/bin/buncher_adaptive.rs
+++ b/docs/examples/src/bin/buncher_adaptive.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[derive(ComponentDefinition, Actor)]
 struct Buncher {
     ctx: ComponentContext<Self>,
-    batch_port: ProvidedPort<Batching, Self>,
+    batch_port: ProvidedPort<Batching>,
     batch_size: usize,
     timeout: Duration,
     current_batch: Vec<Ping>,

--- a/docs/examples/src/bin/buncher_config.rs
+++ b/docs/examples/src/bin/buncher_config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[derive(ComponentDefinition, Actor)]
 struct Buncher {
     ctx: ComponentContext<Self>,
-    batch_port: ProvidedPort<Batching, Self>,
+    batch_port: ProvidedPort<Batching>,
     batch_size: usize,
     timeout: Duration,
     current_batch: Vec<Ping>,

--- a/docs/examples/src/bin/buncher_regular.rs
+++ b/docs/examples/src/bin/buncher_regular.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[derive(ComponentDefinition, Actor)]
 struct Buncher {
     ctx: ComponentContext<Self>,
-    batch_port: ProvidedPort<Batching, Self>,
+    batch_port: ProvidedPort<Batching>,
     batch_size: usize,
     timeout: Duration,
     current_batch: Vec<Ping>,

--- a/docs/examples/src/bin/counters.rs
+++ b/docs/examples/src/bin/counters.rs
@@ -18,7 +18,7 @@ impl Port for CounterPort {
 #[derive(ComponentDefinition)]
 struct Counter {
     ctx: ComponentContext<Self>,
-    counter_port: ProvidedPort<CounterPort, Self>,
+    counter_port: ProvidedPort<CounterPort>,
     msg_count: u64,
     event_count: u64,
 }

--- a/docs/examples/src/bin/counters_channel_pool.rs
+++ b/docs/examples/src/bin/counters_channel_pool.rs
@@ -18,7 +18,7 @@ impl Port for CounterPort {
 #[derive(ComponentDefinition)]
 struct Counter {
     ctx: ComponentContext<Self>,
-    counter_port: ProvidedPort<CounterPort, Self>,
+    counter_port: ProvidedPort<CounterPort>,
     msg_count: u64,
     event_count: u64,
 }

--- a/docs/examples/src/bin/counters_pool.rs
+++ b/docs/examples/src/bin/counters_pool.rs
@@ -18,7 +18,7 @@ impl Port for CounterPort {
 #[derive(ComponentDefinition)]
 struct Counter {
     ctx: ComponentContext<Self>,
-    counter_port: ProvidedPort<CounterPort, Self>,
+    counter_port: ProvidedPort<CounterPort>,
     msg_count: u64,
     event_count: u64,
 }

--- a/docs/examples/src/bin/leader_election.rs
+++ b/docs/examples/src/bin/leader_election.rs
@@ -8,7 +8,7 @@ struct UpdateProcesses(Arc<[ActorPath]>);
 #[derive(ComponentDefinition)]
 struct EventualLeaderElector {
     ctx: ComponentContext<Self>,
-    omega_port: ProvidedPort<EventualLeaderDetection, Self>,
+    omega_port: ProvidedPort<EventualLeaderDetection>,
     processes: Arc<[ActorPath]>,
     candidates: HashSet<ActorPath>,
     period: Duration,

--- a/docs/examples/src/bin/serialisation.rs
+++ b/docs/examples/src/bin/serialisation.rs
@@ -139,7 +139,7 @@ impl NetworkActor for BootstrapServer {
 #[derive(ComponentDefinition)]
 struct EventualLeaderElector {
     ctx: ComponentContext<Self>,
-    omega_port: ProvidedPort<EventualLeaderDetection, Self>,
+    omega_port: ProvidedPort<EventualLeaderDetection>,
     bootstrap_server: ActorPath,
     processes: Box<[ActorPath]>,
     candidates: HashSet<ActorPath>,

--- a/docs/examples/src/bin/workers.rs
+++ b/docs/examples/src/bin/workers.rs
@@ -76,7 +76,7 @@ impl Port for WorkerPort {
 #[derive(ComponentDefinition)]
 struct Manager {
     ctx: ComponentContext<Self>,
-    worker_port: RequiredPort<WorkerPort, Self>,
+    worker_port: RequiredPort<WorkerPort>,
     num_workers: usize,
     workers: Vec<Arc<Component<Worker>>>,
     worker_refs: Vec<ActorRefStrong<WorkPart>>,
@@ -192,7 +192,7 @@ impl Actor for Manager {
 #[derive(ComponentDefinition)]
 struct Worker {
     ctx: ComponentContext<Self>,
-    worker_port: ProvidedPort<WorkerPort, Self>,
+    worker_port: ProvidedPort<WorkerPort>,
 }
 impl Worker {
     fn new() -> Self {

--- a/docs/examples/src/trusting.rs
+++ b/docs/examples/src/trusting.rs
@@ -19,7 +19,7 @@ impl Port for EventualLeaderDetection {
 #[derive(ComponentDefinition, Actor)]
 pub struct TrustPrinter {
     ctx: ComponentContext<Self>,
-    omega_port: RequiredPort<EventualLeaderDetection, Self>,
+    omega_port: RequiredPort<EventualLeaderDetection>,
 }
 impl TrustPrinter {
     pub fn new() -> Self {

--- a/experiments/dynamic-benches/src/actorrefs.rs
+++ b/experiments/dynamic-benches/src/actorrefs.rs
@@ -22,7 +22,7 @@ impl Port for TestPort {
 #[derive(ComponentDefinition)]
 pub struct TestActor {
     ctx: ComponentContext<Self>,
-    testp: ProvidedPort<TestPort, Self>,
+    testp: ProvidedPort<TestPort>,
 }
 
 impl TestActor {

--- a/experiments/dynamic-benches/src/network_latency.rs
+++ b/experiments/dynamic-benches/src/network_latency.rs
@@ -311,7 +311,7 @@ pub mod pppipelinestatic {
     #[derive(ComponentDefinition)]
     pub struct Pinger {
         ctx: ComponentContext<Self>,
-        experiment_port: ProvidedPort<ExperimentPort, Self>,
+        experiment_port: ProvidedPort<ExperimentPort>,
         ponger: ActorPath,
         remaining_send: u64,
         remaining_recv: u64,
@@ -526,7 +526,7 @@ pub mod pppipelineindexed {
     #[derive(ComponentDefinition)]
     pub struct Pinger {
         ctx: ComponentContext<Self>,
-        experiment_port: ProvidedPort<ExperimentPort, Self>,
+        experiment_port: ProvidedPort<ExperimentPort>,
         ponger: ActorPath,
         remaining_send: u64,
         remaining_recv: u64,
@@ -756,7 +756,7 @@ pub mod ppstatic {
     #[derive(ComponentDefinition)]
     pub struct Pinger {
         ctx: ComponentContext<Self>,
-        experiment_port: ProvidedPort<ExperimentPort, Self>,
+        experiment_port: ProvidedPort<ExperimentPort>,
         ponger: ActorPath,
         remaining: u64,
         done: Option<KPromise<Duration>>,
@@ -971,7 +971,7 @@ pub mod ppstatic {
         #[derive(ComponentDefinition)]
         pub struct Pinger {
             ctx: ComponentContext<Self>,
-            experiment_port: ProvidedPort<ExperimentPort, Self>,
+            experiment_port: ProvidedPort<ExperimentPort>,
             done: Option<KPromise<Duration>>,
             ponger: ActorPath,
             count: u64,
@@ -1137,7 +1137,7 @@ pub mod ppindexed {
     #[derive(ComponentDefinition)]
     pub struct Pinger {
         ctx: ComponentContext<Self>,
-        experiment_port: ProvidedPort<ExperimentPort, Self>,
+        experiment_port: ProvidedPort<ExperimentPort>,
         ponger: ActorPath,
         remaining: u64,
         done: Option<KPromise<Duration>>,

--- a/macros/component-definition-derive/src/lib.rs
+++ b/macros/component-definition-derive/src/lib.rs
@@ -163,6 +163,33 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> TokenStream2 {
         // if !port_ref_impls.is_empty() {
         // println!("PortRefImpls: {}",port_ref_impls[0]);
         // }
+
+        fn make_match(f: &syn::Field, t: &syn::Type) -> TokenStream2 {
+            let f = &f.ident;
+            quote! {
+                id if id == ::std::any::TypeId::of::<#t>() =>
+                    Some(&mut self.#f as &mut dyn ::std::any::Any),
+            }
+        }
+
+        let provided_matches: Vec<_> = ports
+            .iter()
+            .filter_map(|(f, p)| match p {
+                PortField::Provided(t) => Some((*f, t)),
+                _ => None,
+            })
+            .map(|(f, t)| make_match(f, t))
+            .collect();
+
+        let required_matches: Vec<_> = ports
+            .iter()
+            .filter_map(|(f, p)| match p {
+                PortField::Required(t) => Some((*f, t)),
+                _ => None,
+            })
+            .map(|(f, t)| make_match(f, t))
+            .collect();
+
         quote! {
             impl #impl_generics ComponentDefinition for #name #ty_generics #where_clause {
                 fn setup(&mut self, self_component: ::std::sync::Arc<Component<Self>>) -> () {
@@ -179,6 +206,23 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> TokenStream2 {
                 }
                 fn type_name() -> &'static str {
                     #name_str
+                }
+            }
+            impl #impl_generics DynamicPortAccess for #name #ty_generics #where_clause {
+                #[doc(hidden)] // internal api
+                fn get_provided_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
+                    match port_id {
+                        #(#provided_matches),*
+                        _ => None,
+                    }
+                }
+
+                #[doc(hidden)] // internal api
+                fn get_required_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
+                    match port_id {
+                        #(#required_matches),*
+                        _ => None,
+                    }
                 }
             }
             #(#port_ref_impls)*

--- a/macros/component-definition-derive/src/lib.rs
+++ b/macros/component-definition-derive/src/lib.rs
@@ -209,7 +209,6 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> TokenStream2 {
                 }
             }
             impl #impl_generics DynamicPortAccess for #name #ty_generics #where_clause {
-                #[doc(hidden)] // internal api
                 fn get_provided_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
                     match port_id {
                         #(#provided_matches),*
@@ -217,7 +216,6 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> TokenStream2 {
                     }
                 }
 
-                #[doc(hidden)] // internal api
                 fn get_required_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
                     match port_id {
                         #(#required_matches),*

--- a/macros/macro-test/src/main.rs
+++ b/macros/macro-test/src/main.rs
@@ -18,8 +18,8 @@ impl Port for PingPongPort {
 #[derive(ComponentDefinition, Actor)]
 struct Pinger {
     ctx: ComponentContext<Pinger>,
-    ppp: RequiredPort<PingPongPort, Pinger>,
-    pppp: ProvidedPort<PingPongPort, Pinger>,
+    ppp: RequiredPort<PingPongPort>,
+    pppp: ProvidedPort<PingPongPort>,
     test: i32,
 }
 


### PR DESCRIPTION
With #69 I added a way to create type-erased `Components` from type-erased `ComponentDefinition`s. You could even create actor references to them as usual and all was fine and dandy.

Well, mostly. You had no way of referring to the component's ports because you didn't know the concrete type! And there was no API to look ports up dynamically. This PR adds just that.

The `DynamicPortAccess` trait provides a low-level API for getting mutable refs to required/provided ports. The methods take a `TypeId` and return a `&mut dyn Any`. The lookup works by simply comparing the type ids. The implementation of this trait is generated automatically by the `#[derive(ComponentDefinition)]` macro. There is a more strictly-typed API implemented on top of that for `dyn DynamicComponentDefinition` trait objects. 

Speaking of `dyn DynamicComponentDefinition` - this one is also new. It's just the combination of all the object-safe super-traits of the `ComponentDefinition` trait, and is now obtainable from an `Arc<dyn AbstractComponent>` via `lock_dyn_definition`, `dyn_definition_mut`, and `on_dyn_definition`. Those are analogous to the definition-retrieving functions for the `Component` type.

There's an easily noticeable breaking change in this one. `{Provided,Required}Port` lost their last type parameter, which was the parent component definition type. The whole goal of this PR was to be able to do more with knowing fewer of the types, so it had to go. This change probably requires a few small updates in the book and it will break some projects (but it's trivially fixable).