### PR TITLE
ComponentDefinition macro bugg-fix

### DIFF
--- a/macros/component-definition-derive/src/lib.rs
+++ b/macros/component-definition-derive/src/lib.rs
@@ -219,14 +219,14 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> TokenStream2 {
             impl #impl_generics DynamicPortAccess for #name #ty_generics #where_clause {
                 fn get_provided_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
                     match port_id {
-                        #(#provided_matches),*
+                        #(#provided_matches)*
                         _ => None,
                     }
                 }
 
                 fn get_required_port_as_any(&mut self, port_id: ::std::any::TypeId) -> Option<&mut dyn ::std::any::Any> {
                     match port_id {
-                        #(#required_matches),*
+                        #(#required_matches)*
                         _ => None,
                     }
                 }

--- a/macros/macro-test/src/main.rs
+++ b/macros/macro-test/src/main.rs
@@ -15,6 +15,7 @@ impl Port for PingPongPort {
     type Request = Ping;
 }
 
+
 #[derive(ComponentDefinition, Actor)]
 struct Pinger {
     ctx: ComponentContext<Pinger>,
@@ -49,6 +50,51 @@ impl Require<PingPongPort> for Pinger {
 }
 
 impl Provide<PingPongPort> for Pinger {
+    fn handle(&mut self, _event: Ping) -> Handled {
+        println!("Got a ping!");
+        Handled::Ok
+    }
+}
+
+// Tests that the macro allows multiple ports
+#[derive(ComponentDefinition, Actor)]
+struct Pinger2 {
+    ctx: ComponentContext<Pinger2>,
+    ppp: RequiredPort<PingPongPort>,
+    ppp2: RequiredPort<PingPongPort2>,
+    pppp: ProvidedPort<PingPongPort>,
+    test: i32,
+}
+
+struct PingPongPort2;
+
+impl Port for PingPongPort2 {
+    type Indication = Pong;
+    type Request = Ping;
+}
+
+impl ComponentLifecycle for Pinger2 {
+    fn on_start(&mut self) -> Handled {
+        println!("Starting Pinger... {}", self.test);
+        Handled::Ok
+    }
+}
+
+impl Require<PingPongPort> for Pinger2 {
+    fn handle(&mut self, _event: Pong) -> Handled {
+        println!("Got a pong!");
+        Handled::Ok
+    }
+}
+
+impl Require<PingPongPort2> for Pinger2 {
+    fn handle(&mut self, _event: Pong) -> Handled {
+        println!("Got a pong!");
+        Handled::Ok
+    }
+}
+
+impl Provide<PingPongPort> for Pinger2 {
     fn handle(&mut self, _event: Ping) -> Handled {
         println!("Got a ping!");
         Handled::Ok


### PR DESCRIPTION
The ComponentDefinition macro was failing when there were multiple Required/Provided-ports in a component due to the two commas. Added the Pinger2 struct which triggered the issue that is now resolved.