### PR TITLE
Resolving issues for 0.10.0

### DIFF
--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -1126,21 +1126,22 @@ mod tests {
             let mut cfg = KompactConfig::new();
             cfg.system_components(
                 DeadletterBox::new,
-                NetworkConfig::new(SocketAddr::new("127.0.0.1".parse().unwrap(), 9311)).build(),
+                NetworkConfig::new("127.0.0.1:0".parse().expect("Address should work")).build()
             );
             cfg.build().expect("KompactSystem")
         };
-        let system2 = || {
+        let system2 = |port| {
             let mut cfg = KompactConfig::new();
             cfg.system_components(
                 DeadletterBox::new,
-                NetworkConfig::new(SocketAddr::new("127.0.0.1".parse().unwrap(), 9312)).build(),
+                NetworkConfig::new(SocketAddr::new("127.0.0.1".parse().unwrap(), port)).build(),
             );
             cfg.build().expect("KompactSystem")
         };
 
         // Set-up system2a
-        let system2a = system2();
+        let system2a = system2(0);
+        let port = system2a.system_path().port();
         //let (ponger_unique, pouf) = remote.create_and_register(PongerAct::new);
         let (ponger_named, ponf) = system2a.create_and_register(PongerAct::new_lazy);
         let poaf = system2a.register_by_alias(&ponger_named, "custom_name");
@@ -1182,7 +1183,7 @@ mod tests {
 
         // Start up system2b
         println!("Setting up system2b");
-        let system2b = system2();
+        let system2b = system2(port);
         let (ponger_named, ponf) = system2b.create_and_register(PongerAct::new_lazy);
         let poaf = system2b.register_by_alias(&ponger_named, "custom_name");
         ponf.wait_expect(Duration::from_millis(1000), "Ponger failed to register!");

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -483,6 +483,10 @@ impl NetworkDispatcher {
                     warn!(self.ctx().log(), "connection closed for {:?}", addr);
                     self.retry_map.insert(addr, 0); // Make sure we try to re-establish the connection
                 }
+                // Ack the close message
+                if let Some(bridge) = &self.net_bridge {
+                    bridge.ack_closed(addr)?;
+                }
             }
             Error(ref err) => {
                 match err {
@@ -1126,7 +1130,7 @@ mod tests {
             let mut cfg = KompactConfig::new();
             cfg.system_components(
                 DeadletterBox::new,
-                NetworkConfig::new("127.0.0.1:0".parse().expect("Address should work")).build()
+                NetworkConfig::new("127.0.0.1:0".parse().expect("Address should work")).build(),
             );
             cfg.build().expect("KompactSystem")
         };

--- a/core/src/net/buffers/decode_buffer.rs
+++ b/core/src/net/buffers/decode_buffer.rs
@@ -78,7 +78,7 @@ impl DecodeBuffer {
     /// `get_frame()` should be called repeatedly until it returns `FramingError::NoData`
     /// before calling this method.
     pub fn swap_buffer(&mut self, other: &mut BufferChunk) -> () {
-        assert!(!other.locked, "Swapping with locked buffer");
+        assert!(other.free(), "Swapping with locked buffer");
         let overflow = self.get_overflow();
         self.buffer.swap_buffer(other);
         self.read_offset = 0;

--- a/core/src/net/buffers/decode_buffer.rs
+++ b/core/src/net/buffers/decode_buffer.rs
@@ -219,6 +219,11 @@ impl DecodeBuffer {
         }
         None
     }
+
+    /// Destroys the DecodeBuffer and returns the BufferChunk
+    pub(crate) fn destroy(self) -> BufferChunk {
+        self.buffer
+    }
 }
 
 #[cfg(test)]

--- a/core/src/net/buffers/encode_buffer.rs
+++ b/core/src/net/buffers/encode_buffer.rs
@@ -29,7 +29,7 @@ impl EncodeBuffer {
                 min_remaining: config.encode_buf_min_free_space,
             }
         } else {
-            panic!("Couldn't initialize EncodeBuffer");
+            panic!("Couldn't initialize EncodeBuffer, No available chunks in the pool");
         }
     }
 
@@ -50,7 +50,7 @@ impl EncodeBuffer {
                 min_remaining: config.encode_buf_min_free_space,
             }
         } else {
-            panic!("Couldn't initialize EncodeBuffer");
+            panic!("Couldn't initialize EncodeBuffer, No available chunks in the pool");
         }
     }
 

--- a/core/src/net/buffers/mod.rs
+++ b/core/src/net/buffers/mod.rs
@@ -80,8 +80,8 @@ impl BufferConfig {
         if let Some(initial_chunk_count) = config["buffer_config"]["initial_chunk_count"].as_i64() {
             buffer_config.initial_chunk_count = initial_chunk_count as usize;
         }
-        if let Some(max_pool_count) = config["buffer_config"]["max_pool_count"].as_i64() {
-            buffer_config.max_chunk_count = max_pool_count as usize;
+        if let Some(max_chunk_count) = config["buffer_config"]["max_chunk_count"].as_i64() {
+            buffer_config.max_chunk_count = max_chunk_count as usize;
         }
         if let Some(encode_min_remaining) = config["buffer_config"]["encode_min_remaining"].as_i64()
         {
@@ -95,7 +95,7 @@ impl BufferConfig {
     /// Is called automatically by the `BufferPool` on creation.
     pub fn validate(&self) {
         if self.initial_chunk_count > self.max_chunk_count {
-            panic!("initial_chunk_count may not be greater than max_pool_count")
+            panic!("initial_chunk_count may not be greater than max_chunk_count")
         }
         if self.chunk_size <= self.encode_buf_min_free_space {
             panic!("chunk_size must be greater than encode_min_remaining")
@@ -295,7 +295,7 @@ mod tests {
     // replace ignore with panic cfg gate when https://github.com/rust-lang/rust/pull/74754 is merged
     #[test]
     #[ignore]
-    #[should_panic(expected = "initial_chunk_count may not be greater than max_pool_count")]
+    #[should_panic(expected = "initial_chunk_count may not be greater than max_chunk_count")]
     fn invalid_pool_counts_config_validation() {
         let hocon = HoconLoader::new()
             .load_str(
@@ -303,7 +303,7 @@ mod tests {
             buffer_config {
                 chunk_size: 64,
                 initial_chunk_count: 3,
-                max_pool_count: 2,
+                max_chunk_count: 2,
                 encode_min_remaining: 2,
                 }
             }"#,
@@ -395,7 +395,7 @@ mod tests {
                 buffer_config {
                     chunk_size: 256,
                     initial_chunk_count: 3,
-                    max_pool_count: 4,
+                    max_chunk_count: 4,
                     encode_min_remaining: 20,
                     }
                 }"#,

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -82,6 +82,8 @@ pub mod events {
         Stop,
         /// Tells the network adress to open up a channel to the SocketAddr
         Connect(SocketAddr),
+        /// Acknowledges a closed channel, required to ensure FIFO ordering under connection loss
+        ClosedAck(SocketAddr),
     }
 
     /// Errors emitted byt the network `Bridge`
@@ -312,6 +314,14 @@ impl Bridge {
             }
             _other => Err(NetworkBridgeErr::Other("Bad Protocol".to_string())),
         }
+    }
+
+    /// Acknowledges a closed channel, required to ensure FIFO ordering under connection loss
+    pub fn ack_closed(&self, addr: SocketAddr) -> Result<(), NetworkBridgeErr> {
+        self.network_input_queue
+            .send(events::DispatchEvent::ClosedAck(addr))?;
+        self.waker.wake()?;
+        Ok(())
     }
 }
 

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -357,14 +357,14 @@ impl NetworkThread {
     fn handle_start(&mut self, token: Token, remote_addr: SocketAddr, id: Uuid) -> () {
         if let Some(registered_addr) = self.token_map.remove(&token) {
             if remote_addr == registered_addr {
+                // The channel we received the start on was already registered with the appropriate address.
+                // There is no need to change anything, we can simply transition the channel.
                 debug!(
                     self.log,
                     "Got Start({}, ...) from {}, already registered with correct addr",
                     &remote_addr,
                     &registered_addr
                 );
-            // The channel we received the start on was already registered with the appropriate address.
-            // There is no need to change anything, we can simply transition the channel.
             } else {
                 // Make sure we only have one channel and that it's registered with the remote_addr
                 if let Some(mut channel) = self.channel_map.remove(&registered_addr) {
@@ -377,7 +377,8 @@ impl NetworkThread {
                         if let Some(other_id) = other_channel.get_id() {
                             // The other channel has a known id, if it doesn't there is no reason to keep it.
 
-                            if other_channel.connected() || other_id > id {
+                            if other_channel.connected() || other_id > id || other_channel.closed()
+                            {
                                 // The other channel should be kept and this one should be discarded.
                                 debug!(
                                     self.log,
@@ -611,21 +612,34 @@ impl NetworkThread {
         if let Some(channel) = self.channel_map.remove(&addr) {
             // We already have a connection set-up
             // the connection request must have been sent before the channel was initialized
-            if let ChannelState::Connected(_0, _1) = channel.state {
-                // log and inform Dispatcher to make sure it knows we're connected.
-                debug!(
-                    self.log,
-                    "Asked to request connection to already connected host {}", &addr
-                );
-                self.dispatcher_ref
-                    .tell(DispatchEnvelope::Event(EventEnvelope::Network(
-                        NetworkEvent::Connection(addr, ConnectionState::Connected(addr)),
-                    )));
-                self.channel_map.insert(addr, channel);
-                return Ok(());
-            } else {
-                // It was an old attempt, remove it and continue with the new request
-                drop(channel);
+            match channel.state {
+                ChannelState::Connected(_, _) => {
+                    // log and inform Dispatcher to make sure it knows we're connected.
+                    debug!(
+                        self.log,
+                        "Asked to request connection to already connected host {}", &addr
+                    );
+                    self.dispatcher_ref
+                        .tell(DispatchEnvelope::Event(EventEnvelope::Network(
+                            NetworkEvent::Connection(addr, ConnectionState::Connected(addr)),
+                        )));
+                    self.channel_map.insert(addr, channel);
+                    return Ok(());
+                }
+                ChannelState::Closed(_, _) => {
+                    // We're waiting for the ClosedAck from the NetworkDispatcher
+                    // This shouldn't happen but the system will likely recover from it eventually
+                    debug!(
+                        self.log,
+                        "Requested connection to host before receiving ClosedAck {}", &addr
+                    );
+                    self.channel_map.insert(addr, channel);
+                    return Ok(());
+                }
+                _ => {
+                    // It was an old attempt, remove it and continue with the new request
+                    drop(channel);
+                }
             }
         }
         debug!(self.log, "Requesting connection to {}", &addr);
@@ -746,13 +760,19 @@ impl NetworkThread {
                     debug!(self.log, "Got DispatchEvent::Connect({})", addr);
                     self.request_stream(addr)?;
                 }
+                DispatchEvent::ClosedAck(addr) => {
+                    debug!(self.log, "Got DispatchEvent::ClosedAck({})", addr);
+                    self.handle_closed_ack(addr);
+                }
             }
         }
         Ok(())
     }
 
     fn close_channel(&mut self, addr: SocketAddr) -> () {
-        if let Some(mut channel) = self.channel_map.remove(&addr) {
+        // We will only drop the Channel once we get the CloseAck from the NetworkDispatcher
+        // Which ensures that the
+        if let Some(channel) = self.channel_map.get_mut(&addr) {
             self.dispatcher_ref
                 .tell(DispatchEnvelope::Event(EventEnvelope::Network(
                     NetworkEvent::Connection(addr, ConnectionState::Closed),
@@ -764,7 +784,21 @@ impl NetworkThread {
                     )));
             }
             channel.shutdown();
-            drop(channel);
+        }
+    }
+
+    fn handle_closed_ack(&mut self, addr: SocketAddr) -> () {
+        if let Some(channel) = self.channel_map.remove(&addr) {
+            match channel.state {
+                ChannelState::Connected(_, _) => {
+                    error!(self.log, "ClosedAck for connected Channel: {:#?}", channel);
+                    self.channel_map.insert(addr, channel);
+                }
+                _ => {
+                    let buffer = channel.destroy();
+                    self.buffer_pool.return_buffer(buffer);
+                }
+            }
         }
     }
 
@@ -854,7 +888,6 @@ mod tests {
         NetworkThread,
         Sender<DispatchEvent>,
     ) {
-
         let mut cfg = KompactConfig::new();
         cfg.system_components(DeadletterBox::new, NetworkConfig::default().build());
         let system = cfg.build().expect("KompactSystem");
@@ -872,7 +905,7 @@ mod tests {
         // Set up the two network threads
         let (network_thread1, _) = NetworkThread::new(
             logger.clone(),
-        "127.0.0.1:0".parse().expect("Address should work"),
+            "127.0.0.1:0".parse().expect("Address should work"),
             lookup.clone(),
             input_queue_1_receiver,
             dispatch_shutdown_sender1,
@@ -882,7 +915,7 @@ mod tests {
 
         let (network_thread2, _) = NetworkThread::new(
             logger,
-        "127.0.0.1:0".parse().expect("Address should work"),
+            "127.0.0.1:0".parse().expect("Address should work"),
             lookup,
             input_queue_2_receiver,
             dispatch_shutdown_sender2,

--- a/core/src/serialisation/ser_helpers.rs
+++ b/core/src/serialisation/ser_helpers.rs
@@ -131,7 +131,8 @@ where
             assert_eq!(
                 chunk_lease.capacity(),
                 len + FRAME_HEAD_LEN as usize,
-                "Serialized frame length faulty {:#?}", chunk_lease
+                "Serialized frame length faulty {:#?}",
+                chunk_lease
             );
             Ok(chunk_lease)
         }

--- a/core/src/serialisation/ser_helpers.rs
+++ b/core/src/serialisation/ser_helpers.rs
@@ -131,7 +131,7 @@ where
             assert_eq!(
                 chunk_lease.capacity(),
                 len + FRAME_HEAD_LEN as usize,
-                "Serialized frame sizing failed"
+                "Serialized frame length faulty {:#?}", chunk_lease
             );
             Ok(chunk_lease)
         }

--- a/docs/src/distributed/networkbuffers.md
+++ b/docs/src/distributed/networkbuffers.md
@@ -52,7 +52,7 @@ impl ComponentLifecycle for CustomBufferConfigActor {
         let mut buffer_config = BufferConfig::default();
         buffer_config.encode_buf_min_free_space(128);
         buffer_config.max_chunk_count(5);
-        buffer_config.initial_pool_count(4);
+        buffer_config.initial_chunk_count(4);
         buffer_config.chunk_size(256000);
         
         self.ctx.borrow().init_buffers(Some(buffer_config), None);
@@ -70,8 +70,8 @@ cfg.load_config_str(
     r#"{
         buffer_config {
             chunk_size: 256000,
-            initial_pool_count: 3,
-            max_pool_count: 4,
+            initial_chunk_count: 3,
+            max_chunk_count: 4,
             encode_min_remaining: 20,
             }
         }"#,
@@ -88,7 +88,7 @@ The `NetworkDispatcher` and `NetworkThread` are configured separately from the A
 let mut cfg = KompactConfig::new();
 let mut network_buffer_config = BufferConfig::default();
 network_buffer_config.chunk_size(512);
-network_buffer_config.initial_pool_count(2);
+network_buffer_config.initial_chunk_count(2);
 network_buffer_config.max_chunk_count(3);
 network_buffer_config.encode_buf_min_free_space(10);
 cfg.system_components(DeadletterBox::new, {


### PR DESCRIPTION
The NetworkTests have been cleaned up further and are now using automatically assigned ports. Closes #62 

The "Improved error messages" are pretty small in this PR the ChunkChaining PR improved it before and I've gone over the different panics/errors and I couldn't find much that can be improved further without doing much more complex error handling. Imo this closes #93 

- - - 

Harald noticed that the tutorial and Hocon parser was using an incorrect parameter name which is now fixed.

- - - 

The biggest functional change is done in the NetworkDispatcher/NetworkThread communication pattern: 
1. When a `Connected` channel is closed the NetworkThread keeps it in a `Closed` state preventing new channels to the same host from entering a `Connected` state. 
2. When the channel enters the `Closed` state the NetworkDispatcher is notified. 
3. When the NetworkDispatcher receives the Notification it will stop routing messages for that host immediately, and Ack the Closed message. 
4. Finally, when the thread receives the `ClosedAck` the Channel will be destroyed and removed entirely, allowing for a new connection to be established.

I don't have a test-case to test the correctness of the implementation, and I don't have a test-case to produce the error which its trying to fix either because it's a very particular timing issue. 

This closes #67 