### PR TITLE
Update `unsized_locals` -> `unsized_fn_params`

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,7 +71,7 @@
 #![cfg_attr(nightly, feature(never_type))]
 #![cfg_attr(nightly, feature(option_expect_none))]
 #![cfg_attr(nightly, feature(async_closure))]
-#![cfg_attr(nightly, feature(unsized_locals))]
+#![cfg_attr(nightly, feature(unsized_fn_params))] // requires nightly > 2020-10-29
 
 #[cfg(feature = "thread_pinning")]
 pub use core_affinity::{get_core_ids, CoreId};


### PR DESCRIPTION
Fixes #104

Should not be merged right away: this will require a nightly >= 2020-10-29 to compile.
Please refer to the issue for details.