### PR TITLE
More clippy-adjacent suggestions

### DIFF
--- a/core/src/dispatch/lookup/mod.rs
+++ b/core/src/dispatch/lookup/mod.rs
@@ -301,8 +301,8 @@ impl ActorLookup for ActorStore {
                 .expect("Should not be empty")
             {
                 // this is validated above
-                BROADCAST_MARKER => (&path[0..last_index], Some(BROADCAST_MARKER)),
-                SELECT_MARKER => (&path[0..last_index], Some(SELECT_MARKER)),
+                BROADCAST_MARKER => (&path[..last_index], Some(BROADCAST_MARKER)),
+                SELECT_MARKER => (&path[..last_index], Some(SELECT_MARKER)),
                 _ => (path, None),
             };
             match self.name_map.get_node(lookup_path) {

--- a/core/src/messaging/framing.rs
+++ b/core/src/messaging/framing.rs
@@ -190,7 +190,9 @@ impl TryFrom<u8> for SystemPathHeader {
         use bitfields::BitFieldExt;
 
         let storage = [value];
-        let path_type = storage.get_as::<PathType>().unwrap();
+        let path_type = storage
+            .get_as::<PathType>()
+            .map_err(|_| SerError::InvalidData("System Path could not be read.".to_owned()))?;
         let protocol = storage.get_as::<Transport>().unwrap();
         let address_type = storage.get_as::<AddressType>().unwrap();
 

--- a/core/src/net/buffers/chunk_lease.rs
+++ b/core/src/net/buffers/chunk_lease.rs
@@ -146,13 +146,7 @@ impl ChunkLease {
 
     /// Transforms this `ChunkLease` into a [ChunkRef](ChunkRef), an immutable and cloneable smart-pointer
     pub fn into_chunk_ref(self) -> ChunkRef {
-        let chain = {
-            if let Some(chain) = self.chain {
-                Some(Box::new(chain.into_chunk_ref()))
-            } else {
-                None
-            }
-        };
+        let chain = { self.chain.map(|chain| Box::new(chain.into_chunk_ref())) };
         ChunkRef::new(
             self.content,
             self.read_pointer,

--- a/core/src/net/buffers/chunk_lease.rs
+++ b/core/src/net/buffers/chunk_lease.rs
@@ -146,7 +146,7 @@ impl ChunkLease {
 
     /// Transforms this `ChunkLease` into a [ChunkRef](ChunkRef), an immutable and cloneable smart-pointer
     pub fn into_chunk_ref(self) -> ChunkRef {
-        let chain = { self.chain.map(|chain| Box::new(chain.into_chunk_ref())) };
+        let chain = self.chain.map(|chain| Box::new(chain.into_chunk_ref()));
         ChunkRef::new(
             self.content,
             self.read_pointer,

--- a/core/src/net/buffers/decode_buffer.rs
+++ b/core/src/net/buffers/decode_buffer.rs
@@ -152,39 +152,18 @@ impl DecodeBuffer {
                 match head.frame_type() {
                     // Frames with empty bodies should be handled in frame-head decoding below.
                     FrameType::Data => {
-                        if let Ok(data) = Data::decode_from(chunk_lease) {
-                            Ok(data)
-                        } else {
-                            Err(FramingError::InvalidFrame)
-                        }
+                        Data::decode_from(chunk_lease).map_err(|_| FramingError::InvalidFrame)
                     }
-                    FrameType::StreamRequest => {
-                        if let Ok(data) = StreamRequest::decode_from(chunk_lease) {
-                            Ok(data)
-                        } else {
-                            Err(FramingError::InvalidFrame)
-                        }
-                    }
+                    FrameType::StreamRequest => StreamRequest::decode_from(chunk_lease)
+                        .map_err(|_| FramingError::InvalidFrame),
                     FrameType::Hello => {
-                        if let Ok(hello) = Hello::decode_from(chunk_lease) {
-                            Ok(hello)
-                        } else {
-                            Err(FramingError::InvalidFrame)
-                        }
+                        Hello::decode_from(chunk_lease).map_err(|_| FramingError::InvalidFrame)
                     }
                     FrameType::Start => {
-                        if let Ok(start) = Start::decode_from(chunk_lease) {
-                            Ok(start)
-                        } else {
-                            Err(FramingError::InvalidFrame)
-                        }
+                        Start::decode_from(chunk_lease).map_err(|_| FramingError::InvalidFrame)
                     }
                     FrameType::Ack => {
-                        if let Ok(ack) = Ack::decode_from(chunk_lease) {
-                            Ok(ack)
-                        } else {
-                            Err(FramingError::InvalidFrame)
-                        }
+                        Ack::decode_from(chunk_lease).map_err(|_| FramingError::InvalidFrame)
                     }
                     _ => Err(FramingError::UnsupportedFrameType),
                 }

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -213,9 +213,7 @@ impl Bridge {
     pub fn stop(self) -> Result<(), NetworkBridgeErr> {
         debug!(self.log, "Stopping NetworkBridge...");
         self.network_input_queue.send(DispatchEvent::Stop)?;
-        self.waker
-            .wake()
-            .expect("Network Bridge Waking NetworkThread in stop()");
+        self.waker.wake()?;
         self.shutdown_future.wait(); // should block until something is sent
         debug!(self.log, "Stopped NetworkBridge.");
         Ok(())

--- a/experiments/dynamic-benches/src/actor_store/sequence_store.rs
+++ b/experiments/dynamic-benches/src/actor_store/sequence_store.rs
@@ -165,8 +165,8 @@ impl ActorLookup for ActorStore {
                 .expect("Should not be empty")
             {
                 // this is validated above
-                BROADCAST_MARKER => (&path[0..last_index], Some(BROADCAST_MARKER)),
-                SELECT_MARKER => (&path[0..last_index], Some(SELECT_MARKER)),
+                BROADCAST_MARKER => (&path[..last_index], Some(BROADCAST_MARKER)),
+                SELECT_MARKER => (&path[..last_index], Some(SELECT_MARKER)),
                 _ => (path, None),
             };
             match self.name_map.get_node(lookup_path) {


### PR DESCRIPTION
While we're on the subject of code cleanups, this makes a few `map_err` instances pop up and tames a couple panics.

## Administrivia 

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Contributes to #116 

## Breaking Changes

Failure to get a `PathType` in `SystemPathHeader`'s `TryFrom<u8>` no longer panics (and returns an Error instead).
Failure to wake the network thread in the network bridge's stop no longer provokes a crash (but does return an Error).

## Other Changes

`match foo { Ok(bar) => Ok(bar), Err(baz) => Err(quux) }` is `foo.map_err(|baz| quux)`