### PR TITLE
Make Lazy Serialisation happen in the Network Thread

### DIFF
--- a/core/src/actors/paths.rs
+++ b/core/src/actors/paths.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    messaging::{DispatchData, DispatchEnvelope, MsgEnvelope},
+    messaging::{DispatchData, DispatchEnvelope, MsgEnvelope, SerialisedFrame},
     net::buffers::ChunkRef,
 };
 use std::{
@@ -352,9 +352,9 @@ impl ActorPath {
         let msg: Box<dyn Serialisable> = m.into();
         let dst = self.clone();
         let env = DispatchEnvelope::Msg {
-            src: from,
-            dst,
-            msg: DispatchData::Lazy(msg),
+            src: from.clone(),
+            dst: dst.clone(),
+            msg: DispatchData::Lazy(msg, from, dst),
         };
         dispatch.dispatcher_ref().enqueue(MsgEnvelope::Typed(env))
     }
@@ -399,7 +399,7 @@ impl ActorPath {
                 let env = DispatchEnvelope::Msg {
                     src: from,
                     dst: self.clone(),
-                    msg: DispatchData::SerialisedLease(msg),
+                    msg: DispatchData::Serialised(SerialisedFrame::ChunkLease(msg)),
                 };
                 dispatch.dispatcher_ref().enqueue(MsgEnvelope::Typed(env));
                 Ok(())
@@ -443,7 +443,7 @@ impl ActorPath {
             let env = DispatchEnvelope::Msg {
                 src: from,
                 dst: self.clone(),
-                msg: DispatchData::SerialisedRef(msg),
+                msg: DispatchData::Serialised(SerialisedFrame::ChunkRef(msg)),
             };
             dispatch.dispatcher_ref().enqueue(MsgEnvelope::Typed(env));
             Ok(())

--- a/core/src/messaging/mod.rs
+++ b/core/src/messaging/mod.rs
@@ -27,7 +27,7 @@ mod registration;
 pub use registration::*;
 mod serialised;
 pub use serialised::*;
-mod dispatch;
+pub(crate) mod dispatch;
 pub use dispatch::*;
 mod deser_macro;
 pub use deser_macro::*;

--- a/core/src/net/buffers/decode_buffer.rs
+++ b/core/src/net/buffers/decode_buffer.rs
@@ -208,7 +208,7 @@ impl DecodeBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
+    use bytes::{Bytes, BytesMut};
 
     fn test_frame_with_reference_bytes(len: usize) -> (Vec<u8>, Bytes) {
         let mut head = FrameHead::new(FrameType::Data, (len - 9) as usize);

--- a/core/src/net/frames.rs
+++ b/core/src/net/frames.rs
@@ -260,10 +260,6 @@ impl FrameHead {
     pub(crate) fn frame_type(&self) -> FrameType {
         self.frame_type
     }
-
-    pub(crate) fn encoded_len() -> usize {
-        FRAME_HEAD_LEN as usize
-    }
 }
 
 impl StreamRequest {

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1068,7 +1068,7 @@ fn remote_delivery_overflow_network_thread_buffers() {
     // This config is also used when giving up on running out of buffers.
     // The big_pinger_system will occupy all buffers on the ponger_system for 5 seconds
     // And then it will be freed.
-    net_cfg.set_connection_retry_interval(500);
+    net_cfg.set_connection_retry_interval(1000);
     net_cfg.set_max_connection_retry_attempts(10);
 
     let big_pinger_system = system_from_network_config(net_cfg.clone());
@@ -1092,7 +1092,7 @@ fn remote_delivery_overflow_network_thread_buffers() {
     });
     pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
 
-    // Ponger_system blocked for 5 Seconds from this time.
+    // Ponger_system blocked for 10 Seconds from this time.
     ponger_system.start(&ponger_named);
     big_pinger_system.start(&big_pinger_named);
 
@@ -1103,7 +1103,7 @@ fn remote_delivery_overflow_network_thread_buffers() {
     small_pinger_system.start(&small_pinger1_named);
 
     // Give the sytem time to fail to establish connection
-    thread::sleep(Duration::from_millis(1500));
+    thread::sleep(Duration::from_millis(4000));
 
     // Start the second Pinger and assert that small_pinger1 hasn't gotten the pong yet.
     // small_pinger_system.start(&small_pinger2_named);
@@ -1131,7 +1131,7 @@ fn remote_delivery_overflow_network_thread_buffers() {
 
     // Wait for the big_pinger_system connection to time_out
     // and let the small_pinger system establish its connection and succeed with its messages
-    thread::sleep(Duration::from_millis(4000));
+    thread::sleep(Duration::from_millis(20000));
 
     // Assert that small_pinger2 has gotten the pongs.
     let pingfn = small_pinger_system.stop_notify(&small_pinger1_named);


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [✅] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [✅] You reference which issue is being closed in the PR text (if applicable)

## Issues

Closes #120 as I've changed the timers which should make the test run smoother. I'm afraid these Network fringe-case tests won't be waterproof until we have proper simulation in place which is quite a big project.

Closes #95 

## Other Changes

Noticed that message forwarding hadn't been updated to use chaining to avoid reserialization, which has now been fixed. Tried to simplify the code a bit but wasn't able to make stuff as neat as I hoped...