### PR TITLE
Removes panics in SystemPath's TryFrom<u8>

### DIFF
--- a/core/src/messaging/framing.rs
+++ b/core/src/messaging/framing.rs
@@ -193,8 +193,12 @@ impl TryFrom<u8> for SystemPathHeader {
         let path_type = storage
             .get_as::<PathType>()
             .map_err(|_| SerError::InvalidData("System Path could not be read.".to_owned()))?;
-        let protocol = storage.get_as::<Transport>().unwrap();
-        let address_type = storage.get_as::<AddressType>().unwrap();
+        let protocol = storage.get_as::<Transport>().map_err(|_| {
+            SerError::InvalidData("System Path Transport could not be read.".to_owned())
+        })?;
+        let address_type = storage.get_as::<AddressType>().map_err(|_| {
+            SerError::InvalidData("System Path AddressType could not be read.".to_owned())
+        })?;
 
         let header = SystemPathHeader {
             storage,


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Fixes #122.

## Breaking Changes

n/a

## Other Changes

Converts the failures in the error case of their enclosing `Result`
(more specifically InvalidData w/ a custom message).
