### PR TITLE
NetworkStatusPort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-01-16
+          toolchain: nightly-2021-02-13
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "62eaa19b325e1b3dc2f7b9b6de544dd536619e3dcf986fc391b2c643f10d68c0"
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -154,7 +154,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -387,12 +387,6 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core_affinity"
@@ -459,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -480,8 +474,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.1",
- "crossbeam-utils 0.8.1",
+ "crossbeam-epoch 0.9.2",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -501,14 +495,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
  "lazy_static",
+ "loom",
  "memoffset 0.6.1",
  "scopeguard",
 ]
@@ -556,13 +550,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -807,9 +802,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -817,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -832,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -842,15 +837,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -859,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-lite"
@@ -880,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -892,24 +887,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -923,6 +915,19 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1038,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1256,6 +1261,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "lru"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -1421,9 +1437,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
 
 [[package]]
 name = "oncemutex"
@@ -1729,7 +1745,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -1842,6 +1858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca43dc3574a38d4090f492dd3ef0d589fc434916a5b40ffc75057595002141a"
+checksum = "65e65d6a9f13cd78f361ea5a2cf53a45d67cdda421ba0316b9be101560f3d207"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -2087,18 +2109,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2251,9 +2273,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,12 +1357,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "socket2",
 ]
 
 [[package]]
@@ -1631,7 +1631,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -1652,7 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -1688,7 +1688,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+checksum = "bca43dc3574a38d4090f492dd3ef0d589fc434916a5b40ffc75057595002141a"
 dependencies = [
  "bitmaps",
  "typenum",

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     component::Handled,
     messaging::{DispatchEnvelope, MsgEnvelope, NetMessage, UnpackError},
+    prelude::NetworkStatusPort,
 };
 use std::{
     fmt,
@@ -10,7 +11,6 @@ use std::{
 
 mod paths;
 mod refs;
-use crate::prelude::NetworkStatusPort;
 pub use paths::*;
 pub use refs::*;
 
@@ -150,10 +150,9 @@ pub trait Actor {
 pub trait Dispatcher: ActorRaw<Message = DispatchEnvelope> {
     /// Returns the system path for this dispatcher
     fn system_path(&mut self) -> SystemPath;
-
-    /// Connects the Dispatcher to the `RequiredPort<NetworkStatusPort>` reference.
-    fn connect_network_status_port(&mut self, required: &mut RequiredPort<NetworkStatusPort>)
-        -> ();
+    /// Returns a mutable pointer to the dispatchers provided NetworkStatusPort
+    /// Can be unimplemented in systems where the NetworkStatusPort is not used
+    fn network_status_port(&mut self) -> &mut ProvidedPort<NetworkStatusPort>;
 }
 
 impl<A, M: MessageBounds> ActorRaw for A

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -10,6 +10,7 @@ use std::{
 
 mod paths;
 mod refs;
+use crate::prelude::NetworkStatusPort;
 pub use paths::*;
 pub use refs::*;
 
@@ -149,6 +150,10 @@ pub trait Actor {
 pub trait Dispatcher: ActorRaw<Message = DispatchEnvelope> {
     /// Returns the system path for this dispatcher
     fn system_path(&mut self) -> SystemPath;
+
+    /// Connects the Dispatcher to the `RequiredPort<NetworkStatusPort>` reference.
+    fn connect_network_status_port(&mut self, required: &mut RequiredPort<NetworkStatusPort>)
+        -> ();
 }
 
 impl<A, M: MessageBounds> ActorRaw for A

--- a/core/src/actors/paths.rs
+++ b/core/src/actors/paths.rs
@@ -189,6 +189,11 @@ impl SystemPath {
         self.into_named_with_vec(parsed)
     }
 
+    /// Returns the SocketAddr corresponding to the SystemPath
+    pub fn socket_address(&self) -> SocketAddr {
+        SocketAddr::new(self.address, self.port)
+    }
+
     /// Create a named path starting with this system path and ending with the sequence of path segments
     ///
     /// Paths created with this function will be validated to be a valid lookup path,

--- a/core/src/default_components.rs
+++ b/core/src/default_components.rs
@@ -59,8 +59,8 @@ impl SystemComponents for DefaultComponents {
         self.stop(system);
     }
 
-    fn connect_network_status_port(&self, _: &mut RequiredPort<NetworkStatusPort>) -> () {
-        unimplemented!("No NetworkDispatcher in DefaultComponents");
+    fn connect_network_status_port(&self, _required: &mut RequiredPort<NetworkStatusPort>) -> () {
+        unimplemented!("System must have a NetworkDispatcher to use the NetworkStatusPort")
     }
 }
 
@@ -147,7 +147,7 @@ where
 
     fn connect_network_status_port(&self, required: &mut RequiredPort<NetworkStatusPort>) -> () {
         self.dispatcher.on_definition(|d| {
-            d.connect_network_status_port(required);
+            utils::biconnect_ports(d.network_status_port(), required);
         })
     }
 }
@@ -263,8 +263,8 @@ impl Dispatcher for LocalDispatcher {
         SystemPath::new(Transport::Local, "127.0.0.1".parse().unwrap(), 0)
     }
 
-    fn connect_network_status_port(&mut self, _: &mut RequiredPort<NetworkStatusPort>) -> () {
-        unimplemented!()
+    fn network_status_port(&mut self) -> &mut ProvidedPort<NetworkStatusPort> {
+        unimplemented!("The LocalDispatcher does not provide a NetworkStatusPort");
     }
 }
 

--- a/core/src/default_components.rs
+++ b/core/src/default_components.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    dispatch::NetworkStatusPort,
     messaging::{DispatchEnvelope, NetMessage},
     timer::timer_manager::TimerRefFactory,
 };
@@ -51,6 +52,15 @@ impl SystemComponents for DefaultComponents {
         system.kill(self.deadletter_box.clone());
         self.dispatcher.wait_ended();
         self.deadletter_box.wait_ended();
+    }
+
+    fn kill(&self, system: &KompactSystem) -> () {
+        // default_components has no graceful shutdown sequence to bypass
+        self.stop(system);
+    }
+
+    fn connect_network_status_port(&self, _: &mut RequiredPort<NetworkStatusPort>) -> () {
+        unimplemented!("No NetworkDispatcher in DefaultComponents");
     }
 }
 
@@ -123,10 +133,22 @@ where
     }
 
     fn stop(&self, system: &KompactSystem) -> () {
+        // Gracefully stop the dispatcher/Network layer.
+        system.stop(&self.dispatcher.clone());
+        self.kill(system);
+    }
+
+    fn kill(&self, system: &KompactSystem) -> () {
         system.kill(self.dispatcher.clone());
         system.kill(self.deadletter_box.clone());
         self.dispatcher.wait_ended();
         self.deadletter_box.wait_ended();
+    }
+
+    fn connect_network_status_port(&self, required: &mut RequiredPort<NetworkStatusPort>) -> () {
+        self.dispatcher.on_definition(|d| {
+            d.connect_network_status_port(required);
+        })
     }
 }
 
@@ -239,6 +261,10 @@ impl Actor for LocalDispatcher {
 impl Dispatcher for LocalDispatcher {
     fn system_path(&mut self) -> SystemPath {
         SystemPath::new(Transport::Local, "127.0.0.1".parse().unwrap(), 0)
+    }
+
+    fn connect_network_status_port(&mut self, _: &mut RequiredPort<NetworkStatusPort>) -> () {
+        unimplemented!()
     }
 }
 

--- a/core/src/dispatch/lookup/gc.rs
+++ b/core/src/dispatch/lookup/gc.rs
@@ -34,7 +34,6 @@ pub struct UpdateStrategy {
     algo: FeedbackAlgorithm,
 }
 
-#[allow(dead_code)]
 pub enum FeedbackAlgorithm {
     Aimd, // additive increase/multiplicative decrease
     Mimd, // multiplicative increase/multiplicative decrease

--- a/core/src/dispatch/lookup/gc.rs
+++ b/core/src/dispatch/lookup/gc.rs
@@ -34,6 +34,7 @@ pub struct UpdateStrategy {
     algo: FeedbackAlgorithm,
 }
 
+#[allow(dead_code)]
 pub enum FeedbackAlgorithm {
     Aimd, // additive increase/multiplicative decrease
     Mimd, // multiplicative increase/multiplicative decrease

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -77,7 +77,7 @@ pub struct NetworkConfig {
 }
 
 impl NetworkConfig {
-    /// Create a new config with `addr` and protocol [Tcp](Transport::Tcp)
+    /// Create a new config with `addr` and protocol [TCP](Transport::Tcp)
     /// NetworkDispatcher and NetworkThread will use the default `BufferConfig`
     pub fn new(addr: SocketAddr) -> Self {
         NetworkConfig {
@@ -91,7 +91,7 @@ impl NetworkConfig {
         }
     }
 
-    /// Create a new config with `addr` and protocol [Tcp](Transport::Tcp)
+    /// Create a new config with `addr` and protocol [TCP](Transport::Tcp)
     /// Note: Only the NetworkThread and NetworkDispatcher will use the `BufferConfig`, not Actors
     pub fn with_buffer_config(addr: SocketAddr, buffer_config: BufferConfig) -> Self {
         buffer_config.validate();
@@ -106,7 +106,7 @@ impl NetworkConfig {
         }
     }
 
-    /// Create a new config with `addr` and protocol [Tcp](Transport::Tcp)
+    /// Create a new config with `addr` and protocol [TCP](Transport::Tcp)
     /// Note: Only the NetworkThread and NetworkDispatcher will use the `BufferConfig`, not Actors
     pub fn with_custom_allocator(
         addr: SocketAddr,
@@ -194,7 +194,7 @@ impl NetworkConfig {
     }
 }
 
-/// Socket defaults to `127.0.0.1:0` (i.e. a random local port) and protocol is [Tcp](Transport::Tcp)
+/// Socket defaults to `127.0.0.1:0` (i.e. a random local port) and protocol is [TCP](Transport::Tcp)
 impl Default for NetworkConfig {
     fn default() -> Self {
         NetworkConfig {
@@ -248,7 +248,7 @@ pub enum NetworkStatusRequest {
 /// This dispatcher automatically creates channels to requested target
 /// systems on demand and maintains them while in use.
 ///
-/// The current implementation only supports [Tcp](Transport::Tcp) as
+/// The current implementation only supports [TCP](Transport::Tcp) as
 /// a transport protocol.
 ///
 /// If possible, this implementation will "reflect" messages
@@ -918,11 +918,8 @@ impl Dispatcher for NetworkDispatcher {
         }
     }
 
-    fn connect_network_status_port(
-        &mut self,
-        required: &mut RequiredPort<NetworkStatusPort>,
-    ) -> () {
-        utils::biconnect_ports(&mut self.network_status_port, required);
+    fn network_status_port(&mut self) -> &mut ProvidedPort<NetworkStatusPort> {
+        &mut self.network_status_port
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -159,12 +159,11 @@ pub mod constants {
 pub mod prelude {
     pub use slog::{crit, debug, error, info, o, trace, warn, Drain, Fuse, Logger};
 
+    pub use bytes::{Buf, BufMut};
     pub use std::{
         any::Any,
         convert::{From, Into},
-    };
-
-    pub use bytes::{Buf, BufMut}; // IntoBuf
+    }; // IntoBuf
 
     pub use kompact_actor_derive::*;
     pub use kompact_component_derive::*;
@@ -248,7 +247,13 @@ pub mod prelude {
 
     pub use crate::{
         default_components::{CustomComponents, DeadletterBox, LocalDispatcher},
-        dispatch::{NetworkConfig, NetworkDispatcher},
+        dispatch::{
+            NetworkConfig,
+            NetworkDispatcher,
+            NetworkStatus,
+            NetworkStatusPort,
+            NetworkStatusRequest,
+        },
         messaging::{
             DispatchEnvelope,
             MsgEnvelope,

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -22,20 +22,20 @@ pub(crate) mod network_thread;
 pub(crate) mod udp_state;
 
 /// The state of a connection
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ConnectionState {
     /// Newly created
     New,
-    /// Still initialising
+    /// Initialising the connection
     Initializing,
-    /// Connected with a confirmed canonical SocketAddr
-    Connected(SocketAddr),
+    /// Connected
+    Connected,
     /// Closed gracefully, by request on either side
     Closed,
     /// Unexpected lost connection
     Lost,
-    /// Threw an error
-    Error(std::io::Error),
+    // Threw an error
+    // Error(std::io::Error),
 }
 
 pub(crate) enum Protocol {
@@ -1156,16 +1156,6 @@ pub mod net_test_helpers {
             debug!(self.ctx.log(), "Sending Status Request. {:?}", request);
             self.network_status_port.trigger(request);
         }
-
-        /*
-        pub fn ask_connection_status(&self) {
-            debug!(self.ctx.log(), "Asking connection status");
-            self.network_status_port.trigger()
-                .ask_with(ConnectionStatusAsk).wait();
-            for conn in connections {
-
-            }
-        }*/
     }
 
     impl ComponentLifecycle for NetworkStatusCounter {

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -1115,7 +1115,8 @@ pub mod net_test_helpers {
     #[derive(ComponentDefinition)]
     pub struct NetworkStatusCounter {
         ctx: ComponentContext<NetworkStatusCounter>,
-        network_status_port: RequiredPort<NetworkStatusPort>,
+        /// The NetworkStatusPort, needs to be exposed to allow connecting to it
+        pub network_status_port: RequiredPort<NetworkStatusPort>,
         /// Counts the number of connection_established messages received
         pub connection_established: u32,
         /// Counts the number of connection_lost messages received

--- a/core/src/net/network_channel.rs
+++ b/core/src/net/network_channel.rs
@@ -30,6 +30,10 @@ pub(crate) enum ChannelState {
     Initialised(SocketAddr, Uuid),
     /// The channel is ready to be used. Ack must be sent before anything else is sent
     Connected(SocketAddr, Uuid),
+    /// Local system initiated a graceful Channel Close, a Bye message must be sent and received
+    CloseRequested(SocketAddr, Uuid),
+    /// Remote system has initiated a graceful Channel Close, a Bye message must be sent
+    CloseReceived(SocketAddr, Uuid),
     /// The channel is closing, will be dropped once the local `NetworkDispatcher` Acks the closing.
     Closed(SocketAddr, Uuid),
 }
@@ -210,21 +214,55 @@ impl TcpChannel {
         }
     }
 
-    pub fn graceful_shutdown(&mut self) -> () {
+    /// Enqueues a Bye message, and attempts to drain the message, returning Ok if the bye was sent
+    pub fn send_bye(&mut self) -> io::Result<()> {
         let mut bye = Frame::Bye();
         let mut bye_bytes = BytesMut::with_capacity(128);
         let len = bye.encoded_len() + FRAME_HEAD_LEN as usize;
         bye_bytes.truncate(len);
-        //hello_bytes.extend_from_slice(&[0;hello.encoded_len()]);
         if let Ok(()) = bye.encode_into(&mut bye_bytes) {
             self.outbound_queue
                 .push_back(SerialisedFrame::Bytes(bye_bytes.freeze()));
             let _ = self.try_drain(); // Try to drain outgoing
-            let _ = self.receive(); // Try to drain incoming
         } else {
             panic!("Unable to send bye bytes, failed to encode!");
         }
-        self.shutdown();
+        if self.outbound_queue.is_empty() {
+            io::Result::Ok(())
+        } else {
+            // Need to wait for the message to be sent again
+            io::Result::Err(Error::new(ErrorKind::Interrupted, "bye not sent"))
+        }
+    }
+
+    /// Handles a Bye message. If the method returns Ok it is safe to shutdown.
+    pub fn handle_bye(&mut self) -> io::Result<()> {
+        match self.state {
+            ChannelState::Connected(addr, id) => {
+                self.state = ChannelState::CloseReceived(addr, id);
+                self.send_bye()?;
+                // Bye has been sent and received, channel is now closed
+                self.state = ChannelState::Closed(addr, id);
+                Ok(())
+            }
+            _ => {
+                // Any other state means we just shut it down.
+                io::Result::Ok(())
+            }
+        }
+    }
+
+    /// If the channel is in connected the channel transitions to CloseRequested
+    /// and calls `clear_outbound_and_send_bye()`
+    /// If the method returns Ok() it must wait for a Bye message to be received.
+    pub fn initiate_graceful_shutdown(&mut self) -> io::Result<()> {
+        match self.state {
+            ChannelState::Connected(addr, id) => {
+                self.state = ChannelState::CloseRequested(addr, id);
+                self.send_bye()
+            }
+            _ => io::Result::Ok(()),
+        }
     }
 
     /// Returns `true` if this channel was not in [ChannelState::Connected](ChannelState::Connected)
@@ -326,6 +364,10 @@ impl TcpChannel {
     pub(crate) fn destroy(self) -> BufferChunk {
         self.input_buffer.destroy()
     }
+
+    pub(crate) fn kill(self) -> () {
+        let _ = self.stream.shutdown(Both);
+    }
 }
 
 impl std::fmt::Debug for TcpChannel {
@@ -364,6 +406,18 @@ impl std::fmt::Debug for ChannelState {
                 .field("id", id)
                 .finish(),
             ChannelState::Closed(addr, id) => f
+                .debug_struct("ChannelState")
+                .field("State", &1)
+                .field("addr", addr)
+                .field("id", id)
+                .finish(),
+            ChannelState::CloseRequested(addr, id) => f
+                .debug_struct("ChannelState")
+                .field("State", &1)
+                .field("addr", addr)
+                .field("id", id)
+                .finish(),
+            ChannelState::CloseReceived(addr, id) => f
                 .debug_struct("ChannelState")
                 .field("State", &1)
                 .field("addr", addr)

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -637,7 +637,7 @@ fn remote_lost_and_continued_connection() {
     });
 
     // We now kill remote_a
-    remote_a.shutdown().ok();
+    remote_a.kill_system().ok();
 
     // Start a new pinger on system
     let (pinger_named2, pinf2) =
@@ -719,7 +719,8 @@ fn remote_lost_and_dropped_connection() {
         assert_eq!(c.count, PING_COUNT);
     });
     // We now kill system2
-    remote_a.shutdown().ok();
+    remote_a.kill_system().ok();
+
     // Start a new pinger on system
     let (pinger_named2, pinf2) =
         system.create_and_register(move || PingerAct::new_lazy(named_path));
@@ -1060,107 +1061,336 @@ fn remote_forwarding_named() {
         .expect("Kompact didn't shut down properly");
 }
 
-// #[test]
-// // Sets up three KompactSystems: One with a BigPonger, one with a BigPinger with big pings
-// // and one with a BigPinger with small pings. The big Pings are sent first and occupies
-// // all buffers of the BigPonger system. The small pings are then sent but can not be received
-// // until the Ponger system closes the Big Ping-channel due to too many retries.
-// // A new batch up small-pings are then sent and replied to.
-// #[ignore]
-// fn remote_delivery_overflow_network_thread_buffers() {
-//     let mut buf_cfg = BufferConfig::default();
-//     buf_cfg.chunk_size(1280);
-//     buf_cfg.max_chunk_count(10);
-//     let mut net_cfg = NetworkConfig::default();
-//     net_cfg.set_buffer_config(buf_cfg.clone());
-//     // We will attempt to establish a connection for 5 seconds before giving up.
-//     // This config is also used when giving up on running out of buffers.
-//     // The big_pinger_system will occupy all buffers on the ponger_system for 5 seconds
-//     // And then it will be freed.
-//     net_cfg.set_connection_retry_interval(1000);
-//     net_cfg.set_max_connection_retry_attempts(10);
+#[test]
+fn network_status_port_established_lost_dropped_connection() {
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_max_connection_retry_attempts(6);
+    net_cfg.set_connection_retry_interval(1000);
+    let local_system = system_from_network_config(net_cfg.clone());
+    let remote_system = system_from_network_config(net_cfg);
 
-//     let big_pinger_system = system_from_network_config(net_cfg.clone());
-//     let ponger_system = system_from_network_config(net_cfg.clone());
-//     let small_pinger_system = system_from_network_config(net_cfg);
+    // Create a status_counter which will listen to the status port and count messages received
+    let (status_counter, _scf) = local_system.create_and_register(NetworkStatusCounter::new);
+    local_system.connect_network_status_port(&status_counter);
+    local_system.start(&status_counter);
 
-//     let (ponger_named, ponf) =
-//         ponger_system.create_and_register(|| BigPongerAct::new_eager(buf_cfg.clone()));
-//     let poaf = ponger_system.register_by_alias(&ponger_named, "custom_name");
-//     let _ = ponf.wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
-//     let ponger_named_path =
-//         poaf.wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
-//     let ponger_named_path1 = ponger_named_path.clone();
-//     let (big_pinger_named, pinf) = big_pinger_system.create_and_register(move || {
-//         BigPingerAct::new_preserialised(ponger_named_path1, 12800, BufferConfig::default())
-//     });
-//     pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
-//     let ponger_named_path2 = ponger_named_path;
-//     let (small_pinger1_named, pinf) = small_pinger_system.create_and_register(move || {
-//         BigPingerAct::new_preserialised(ponger_named_path2, 10, BufferConfig::default())
-//     });
-//     pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
+    // Create a pinger ponger pair such that the Network will be used.
+    let (ponger, _pof) = local_system.create_and_register(PongerAct::new_lazy);
+    let ponger_path = local_system
+        .register_by_alias(&ponger, "ponger")
+        .wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    local_system.start(&ponger);
+    let (pinger, _pif) =
+        remote_system.create_and_register(move || PingerAct::new_lazy(ponger_path));
+    let pinger_path = remote_system
+        .register_by_alias(&ponger, "ponger")
+        .wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    remote_system.start(&pinger);
+    // The systems establish a connection and the pings/pongs are sent
+    thread::sleep(Duration::from_millis(5000));
 
-//     // Ponger_system blocked for 10 Seconds from this time.
-//     ponger_system.start(&ponger_named);
-//     big_pinger_system.start(&big_pinger_named);
+    // Shutdown the remote system and wait for the connection to be lost and dropped by local_system
+    let _ = remote_system.kill_system();
+    thread::sleep(Duration::from_millis(2500));
 
-//     // TODO maybe we could do this a bit more reliable?
-//     thread::sleep(Duration::from_millis(4000));
+    // Make sure the local_system discovers the lost connection
+    let (failing_pinger, _pif) =
+        local_system.create_and_register(move || PingerAct::new_lazy(pinger_path));
+    local_system.start(&failing_pinger);
+    thread::sleep(Duration::from_millis(2500));
 
-//     // remote system should be unable to receive any messages as the BigPing is occupying all buffers
-//     small_pinger_system.start(&small_pinger1_named);
+    // Assert connection lost but not dropped
+    status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_established, 1);
+        assert_eq!(sc.connection_lost, 1);
+        assert_eq!(sc.connection_dropped, 0);
+    });
+    // Wait for connection to be dropped
+    thread::sleep(Duration::from_millis(5000));
+    // Assert dropped
+    status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_established, 1);
+        assert_eq!(sc.connection_lost, 1);
+        assert_eq!(sc.connection_dropped, 1);
+    });
+}
 
-//     // Give the sytem time to fail to establish connection
-//     thread::sleep(Duration::from_millis(4000));
+#[test]
+fn network_status_port_close_connection_closed_connection() {
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_max_connection_retry_attempts(2);
+    net_cfg.set_connection_retry_interval(1000);
+    let local_system = system_from_network_config(net_cfg.clone());
+    let remote_system = system_from_network_config(net_cfg);
 
-//     // Start the second Pinger and assert that small_pinger1 hasn't gotten the pong yet.
-//     // small_pinger_system.start(&small_pinger2_named);
-//     let pingfn = small_pinger_system.stop_notify(&small_pinger1_named);
-//     pingfn
-//         .wait_timeout(Duration::from_millis(1000))
-//         .expect("Pinger never stopped!");
-//     small_pinger1_named.on_definition(|c| {
-//         assert_eq!(c.count, 0);
-//     });
-//     small_pinger_system.start(&small_pinger1_named);
+    // Create a status_counter which will listen to the status port and count messages received
+    let (local_status_counter, _lscf) = local_system.create_and_register(NetworkStatusCounter::new);
+    local_system.connect_network_status_port(&local_status_counter);
+    local_system.start(&local_status_counter);
 
-//     // Shutdown big_pinger_system to make sure it won't continue blocking.
-//     // Assert that the big_pinger never got anything as a sanity check.
-//     let pingfn = big_pinger_system.stop_notify(&big_pinger_named);
-//     pingfn
-//         .wait_timeout(Duration::from_millis(1000))
-//         .expect("Pinger never stopped!");
-//     big_pinger_named.on_definition(|c| {
-//         assert_eq!(c.count, 0);
-//     });
-//     big_pinger_system
-//         .shutdown()
-//         .expect("Kompact didn't shut down properly");
+    let (remote_status_counter, _rscf) =
+        remote_system.create_and_register(NetworkStatusCounter::new);
+    remote_system.connect_network_status_port(&remote_status_counter);
+    remote_system.start(&remote_status_counter);
 
-//     // Wait for the big_pinger_system connection to time_out
-//     // and let the small_pinger system establish its connection and succeed with its messages
-//     thread::sleep(Duration::from_millis(20000));
+    // Create a pinger ponger pair such that the Network will be used.
+    let (ponger, _pof) = local_system.create_and_register(PongerAct::new_lazy);
+    let pnf = local_system.register_by_alias(&ponger, "ponger");
+    local_system.start(&ponger);
+    let ponger_path = pnf.wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    let local_system_path = ponger_path.system().clone();
+    let (pinger, _pif) =
+        remote_system.create_and_register(move || PingerAct::new_lazy(ponger_path));
+    remote_system.start(&pinger);
+    // The systems establish a connection and the pings/pongs are sent
+    thread::sleep(Duration::from_millis(3000));
 
-//     // Assert that small_pinger2 has gotten the pongs.
-//     let pingfn = small_pinger_system.stop_notify(&small_pinger1_named);
-//     pingfn
-//         .wait_timeout(Duration::from_millis(1000))
-//         .expect("Pinger never stopped!");
-//     small_pinger1_named.on_definition(|c| {
-//         assert_eq!(c.count, 2 * PING_COUNT);
-//     });
+    remote_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::DisconnectSystem(local_system_path));
+    });
 
-//     // Shut down the ponger
-//     let pongfn = ponger_system.kill_notify(ponger_named);
-//     pongfn
-//         .wait_timeout(Duration::from_millis(1000))
-//         .expect("Ponger never died!");
+    // Wait for the channel to be closed
+    thread::sleep(Duration::from_millis(5000));
+    local_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_closed, 1);
+    });
 
-//     ponger_system
-//         .shutdown()
-//         .expect("Kompact didn't shut down properly");
-//     small_pinger_system
-//         .shutdown()
-//         .expect("Kompact didn't shut down properly");
-// }
+    remote_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_closed, 1);
+    });
+}
+
+/*
+#[test]
+fn network_status_port_connected_and_disconnected_requests() {
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_max_connection_retry_attempts(2);
+    net_cfg.set_connection_retry_interval(1000);
+    let ponger_system = system_from_network_config(net_cfg.clone());
+    let connection_system = system_from_network_config(net_cfg.clone());
+    let disconnection_system = system_from_network_config(net_cfg);
+
+    // Create a status_counter which will listen to the status port and count messages received
+    let (local_status_counter, _lscf) =
+        ponger_system.create_and_register(NetworkStatusCounter::new);
+    ponger_system.connect_network_status_port(&local_status_counter);
+    ponger_system.start(&local_status_counter);
+
+    let (connection_status_counter, _rscf) =
+        connection_system.create_and_register(NetworkStatusCounter::new);
+    connection_system.connect_network_status_port(&connection_status_counter);
+    connection_system.start(&connection_status_counter);
+
+    let (disconnection_status_counter, _rscf) =
+        disconnection_system.create_and_register(NetworkStatusCounter::new);
+    disconnection_system.connect_network_status_port(&disconnection_status_counter);
+    disconnection_system.start(&disconnection_status_counter);
+
+    // Create a ponger and two pingers pair such that the Network will be used.
+    let (ponger, _pof) = ponger_system.create_and_register(PongerAct::new_lazy);
+    let ponger_path = ponger_system
+        .register_by_alias(&ponger, "ponger")
+        .wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    ponger_system.start(&ponger);
+    let ponger_path_clone = ponger_path.clone();
+    let ponger_path_clone2 = ponger_path.clone();
+    let ponger_system_path = ponger_path.system().clone();
+
+    let (pinger, _pif) =
+        connection_system.create_and_register(move || PingerAct::new_lazy(ponger_path_clone));
+    let pinger_path = connection_system
+        .register_by_alias(&pinger, "pinger")
+        .wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
+    connection_system.start(&pinger);
+    let connection_system_path = pinger_path.system().clone();
+
+    let (pinger2, _pif) =
+        disconnection_system.create_and_register(move || PingerAct::new_lazy(ponger_path_clone2));
+    let pinger2_path = disconnection_system
+        .register_by_alias(&pinger2, "pinger")
+        .wait_expect(Duration::from_millis(1000), "Pinger2 failed to register!");
+    disconnection_system.start(&pinger2);
+    let disconnection_system_path = pinger2_path.system().clone();
+
+    // The systems establish a connection and the pings/pongs are sent, then close one channel
+    thread::sleep(Duration::from_millis(3000));
+    local_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::DisconnectSystem(
+            disconnection_system_path.clone(),
+        ));
+    });
+    thread::sleep(Duration::from_millis(3000));
+
+    // Send the status requests
+    connection_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::DisconnectedSystems);
+        sc.send_status_request(NetworkStatusRequest::ConnectedSystems);
+    });
+    disconnection_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::ConnectedSystems);
+        sc.send_status_request(NetworkStatusRequest::DisconnectedSystems);
+    });
+    local_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::DisconnectedSystems);
+        sc.send_status_request(NetworkStatusRequest::ConnectedSystems);
+    });
+
+    // Wait for the messages then assert
+    thread::sleep(Duration::from_millis(3000));
+    local_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connected_systems[0], connection_system_path);
+        assert_eq!(sc.disconnected_systems[0], disconnection_system_path);
+    });
+    disconnection_status_counter.on_definition(|sc| {
+        assert_eq!(sc.disconnected_systems[0], ponger_system_path);
+        assert!(sc.connected_systems.is_empty());
+    });
+    connection_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connected_systems[0], ponger_system_path);
+        assert!(sc.disconnected_systems.is_empty());
+    });
+}
+ */
+
+#[test]
+fn network_status_port_open_close_open() {
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_max_connection_retry_attempts(2);
+    net_cfg.set_connection_retry_interval(1000);
+    let local_system = system_from_network_config(net_cfg.clone());
+    let remote_system = system_from_network_config(net_cfg);
+
+    let system_path = remote_system.system_path();
+    // Create a status_counter which will listen to the status port and count messages received
+    let (local_status_counter, _lscf) = local_system.create_and_register(NetworkStatusCounter::new);
+    local_system.connect_network_status_port(&local_status_counter);
+    local_system.start(&local_status_counter);
+
+    local_status_counter.on_definition(|sc| {
+        sc.send_status_request(NetworkStatusRequest::ConnectSystem(system_path.clone()));
+    });
+    thread::sleep(Duration::from_millis(3000));
+    local_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_established, 1);
+        assert_eq!(sc.connection_closed, 0);
+        sc.send_status_request(NetworkStatusRequest::DisconnectSystem(system_path.clone()));
+    });
+    thread::sleep(Duration::from_millis(3000));
+    local_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_established, 1);
+        assert_eq!(sc.connection_closed, 1);
+        sc.send_status_request(NetworkStatusRequest::ConnectSystem(system_path.clone()));
+    });
+    thread::sleep(Duration::from_millis(3000));
+    local_status_counter.on_definition(|sc| {
+        assert_eq!(sc.connection_established, 2);
+        assert_eq!(sc.connection_closed, 1);
+    });
+    let _ = local_system.shutdown();
+    let _ = remote_system.shutdown();
+}
+
+#[test]
+// Sets up three KompactSystems: One with a BigPonger, one with a BigPinger with big pings
+// and one with a BigPinger with small pings. The big Pings are sent first and occupies
+// all buffers of the BigPonger system. The small pings are then sent but can not be received
+// until the Ponger system closes the Big Ping-channel due to too many retries.
+// A new batch up small-pings are then sent and replied to.
+fn remote_delivery_overflow_network_thread_buffers() {
+    let mut buf_cfg = BufferConfig::default();
+    buf_cfg.chunk_size(1280);
+    buf_cfg.max_chunk_count(10);
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_buffer_config(buf_cfg.clone());
+    // We will attempt to establish a connection for 5 seconds before giving up.
+    // This config is also used when giving up on running out of buffers.
+    // The big_pinger_system will occupy all buffers on the ponger_system for 5 seconds
+    // And then it will be freed.
+    net_cfg.set_connection_retry_interval(1000);
+    net_cfg.set_max_connection_retry_attempts(10);
+    let big_pinger_system = system_from_network_config(net_cfg.clone());
+    let ponger_system = system_from_network_config(net_cfg.clone());
+    let small_pinger_system = system_from_network_config(net_cfg);
+
+    // Create the BigPonger on the Ponger system
+    let (ponger_named, ponf) =
+        ponger_system.create_and_register(|| BigPongerAct::new_eager(buf_cfg.clone()));
+    let _ = ponf.wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    let ponger_named_path = ponger_system
+        .register_by_alias(&ponger_named, "custom_name")
+        .wait_expect(Duration::from_millis(1000), "Ponger failed to register!");
+    let ponger_named_path1 = ponger_named_path.clone();
+    let ponger_named_path2 = ponger_named_path.clone();
+
+    // Create the three pingers
+    let (big_pinger_named, pinf) = big_pinger_system.create_and_register(move || {
+        BigPingerAct::new_preserialised(ponger_named_path, 15000, BufferConfig::default())
+    });
+    pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
+    let (small_pinger1_named, pinf) = small_pinger_system.create_and_register(move || {
+        BigPingerAct::new_preserialised(ponger_named_path1, 10, BufferConfig::default())
+    });
+    pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
+    let (small_pinger2_named, pinf) = small_pinger_system.create_and_register(move || {
+        BigPingerAct::new_preserialised(ponger_named_path2, 10, BufferConfig::default())
+    });
+    pinf.wait_expect(Duration::from_millis(1000), "Pinger failed to register!");
+
+    // Ponger_system will be blocked blocked for about 10 Seconds from this point.
+    ponger_system.start(&ponger_named);
+    big_pinger_system.start(&big_pinger_named);
+
+    // Wait for the buffers to run out
+    thread::sleep(Duration::from_millis(4000));
+
+    // remote system should be unable to receive any messages as the BigPing is occupying all buffers
+    small_pinger_system.start(&small_pinger1_named);
+    thread::sleep(Duration::from_millis(4000));
+    // Assert that it failed to ping-pong.
+    small_pinger1_named.on_definition(|c| {
+        assert_eq!(c.count, 0);
+    });
+
+    // Shutdown big_pinger_system to make sure it won't continue blocking.
+    // Assert that the big_pinger never got anything as a sanity check.
+    big_pinger_system
+        .stop_notify(&big_pinger_named)
+        .wait_timeout(Duration::from_millis(1000))
+        .expect("Pinger never stopped!");
+    big_pinger_named.on_definition(|c| {
+        assert_eq!(c.count, 0);
+    });
+    big_pinger_system
+        .shutdown()
+        .expect("Kompact didn't shut down properly");
+
+    thread::sleep(Duration::from_millis(4000));
+
+    // Start the second Pinger.
+    small_pinger_system
+        .start_notify(&small_pinger2_named)
+        .wait_timeout(Duration::from_millis(1000))
+        .expect("Pinger never stopped!");
+    // Wait a long time to make sure that all time-outs occur and the sends are succesfull.
+    thread::sleep(Duration::from_millis(12000));
+    small_pinger_system
+        .stop_notify(&small_pinger1_named)
+        .wait_timeout(Duration::from_millis(1000))
+        .expect("Pinger never stopped!");
+
+    // Shut down the ponger
+    ponger_system
+        .kill_notify(ponger_named)
+        .wait_timeout(Duration::from_millis(1000))
+        .expect("Ponger never died!");
+
+    small_pinger2_named.on_definition(|c| {
+        assert_eq!(c.count, PING_COUNT);
+    });
+    ponger_system
+        .shutdown()
+        .expect("Kompact didn't shut down properly");
+    small_pinger_system
+        .shutdown()
+        .expect("Kompact didn't shut down properly");
+}

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1078,7 +1078,9 @@ fn network_status_port_established_lost_dropped_connection() {
 
     // Create a status_counter which will listen to the status port and count messages received
     let (status_counter, _scf) = local_system.create_and_register(NetworkStatusCounter::new);
-    local_system.connect_network_status_port(&status_counter);
+    status_counter.on_definition(|c| {
+        local_system.connect_network_status_port(&mut c.network_status_port);
+    });
     local_system.start(&status_counter);
 
     // Create a pinger ponger pair such that the Network will be used.
@@ -1129,17 +1131,20 @@ fn network_status_port_close_connection_closed_connection() {
     net_cfg.set_max_connection_retry_attempts(2);
     net_cfg.set_connection_retry_interval(1000);
     let local_system = system_from_network_config(net_cfg.clone());
-    //std::proess::Command::new();
     let remote_system = system_from_network_config(net_cfg);
 
     // Create a status_counter which will listen to the status port and count messages received
     let (local_status_counter, _lscf) = local_system.create_and_register(NetworkStatusCounter::new);
-    local_system.connect_network_status_port(&local_status_counter);
+    local_status_counter.on_definition(|c| {
+        local_system.connect_network_status_port(&mut c.network_status_port);
+    });
     local_system.start(&local_status_counter);
 
     let (remote_status_counter, _rscf) =
         remote_system.create_and_register(NetworkStatusCounter::new);
-    remote_system.connect_network_status_port(&remote_status_counter);
+    remote_status_counter.on_definition(|c| {
+        remote_system.connect_network_status_port(&mut c.network_status_port);
+    });
     remote_system.start(&remote_status_counter);
 
     // Create a pinger ponger pair such that the Network will be used.
@@ -1272,7 +1277,9 @@ fn network_status_port_open_close_open() {
     let system_path = remote_system.system_path();
     // Create a status_counter which will listen to the status port and count messages received
     let (local_status_counter, _lscf) = local_system.create_and_register(NetworkStatusCounter::new);
-    local_system.connect_network_status_port(&local_status_counter);
+    local_status_counter.on_definition(|c| {
+        local_system.connect_network_status_port(&mut c.network_status_port);
+    });
     local_system.start(&local_status_counter);
 
     local_status_counter.on_definition(|sc| {

--- a/docs/examples/src/bin/dns_resolver.rs
+++ b/docs/examples/src/bin/dns_resolver.rs
@@ -6,20 +6,20 @@ use trust_dns_proto::{rr::record_type::RecordType, xfer::dns_request::DnsRequest
 
 // ANCHOR: messages
 #[derive(Debug)]
-struct DNSRequest(String);
+struct DnsRequest(String);
 #[derive(Debug)]
-struct DNSResponse(String);
+struct DnsResponse(String);
 // ANCHOR_END: messages
 
 // ANCHOR: state
 #[derive(ComponentDefinition)]
-struct DNSComponent {
+struct DnsComponent {
     ctx: ComponentContext<Self>,
     resolver: Option<AsyncStdResolver>,
 }
-impl DNSComponent {
+impl DnsComponent {
     pub fn new() -> Self {
-        DNSComponent {
+        DnsComponent {
             ctx: ComponentContext::uninitialised(),
             resolver: None,
         }
@@ -28,7 +28,7 @@ impl DNSComponent {
 // ANCHOR_END: state
 
 // ANCHOR: lifecycle
-impl ComponentLifecycle for DNSComponent {
+impl ComponentLifecycle for DnsComponent {
     fn on_start(&mut self) -> Handled {
         debug!(self.log(), "Starting...");
         Handled::block_on(self, move |mut async_self| async move {
@@ -55,8 +55,8 @@ impl ComponentLifecycle for DNSComponent {
 // ANCHOR_END: lifecycle
 
 // ANCHOR: actor
-impl Actor for DNSComponent {
-    type Message = Ask<DNSRequest, DNSResponse>;
+impl Actor for DnsComponent {
+    type Message = Ask<DnsRequest, DnsResponse>;
 
     fn receive_local(&mut self, msg: Self::Message) -> Handled {
         debug!(self.log(), "Got request for domain: {}", msg.request().0);
@@ -78,7 +78,7 @@ impl Actor for DNSComponent {
                     results.push(format!("{}. {:?}", index, ip));
                 }
                 let result_string = format!("{}:\n   {}", msg.request().0, results.join("\n    "));
-                msg.reply(DNSResponse(result_string)).expect("reply");
+                msg.reply(DnsResponse(result_string)).expect("reply");
                 Handled::Ok
             });
             Handled::Ok
@@ -96,7 +96,7 @@ impl Actor for DNSComponent {
 // ANCHOR: main
 fn main() {
     let system = KompactConfig::default().build().expect("system");
-    let dns_comp = system.create(DNSComponent::new);
+    let dns_comp = system.create(DnsComponent::new);
     let dns_comp_ref = dns_comp.actor_ref().hold().expect("live");
     system.start_notify(&dns_comp).wait();
     println!("System is ready, enter your queries.");
@@ -110,7 +110,7 @@ fn main() {
                     for domain in s.split(',') {
                         let domain = domain.trim();
                         info!(system.logger(), "Sending request for {}", domain);
-                        let query_f = dns_comp_ref.ask(DNSRequest(domain.to_string()));
+                        let query_f = dns_comp_ref.ask(DnsRequest(domain.to_string()));
                         outstanding.push(query_f);
                     }
                     for query_f in outstanding {

--- a/docs/examples/src/bin/serialisation.rs
+++ b/docs/examples/src/bin/serialisation.rs
@@ -9,11 +9,11 @@ use std::{
 };
 
 // ANCHOR: zstser
-struct ZSTSerialiser<T>(T)
+struct ZstSerialiser<T>(T)
 where
     T: Send + Sync + Default + Copy + SerialisationId;
 
-impl<T> Serialiser<T> for &ZSTSerialiser<T>
+impl<T> Serialiser<T> for &ZstSerialiser<T>
 where
     T: Send + Sync + Default + Copy + SerialisationId,
 {
@@ -30,7 +30,7 @@ where
     }
 }
 
-impl<T> Deserialiser<T> for ZSTSerialiser<T>
+impl<T> Deserialiser<T> for ZstSerialiser<T>
 where
     T: Send + Sync + Default + Copy + SerialisationId,
 {
@@ -48,7 +48,7 @@ impl SerialisationId for CheckIn {
     const SER_ID: SerId = 2345;
 }
 
-static CHECK_IN_SER: ZSTSerialiser<CheckIn> = ZSTSerialiser(CheckIn);
+static CHECK_IN_SER: ZstSerialiser<CheckIn> = ZstSerialiser(CheckIn);
 // ANCHOR_END: zstser
 
 // ANCHOR: serialisable
@@ -127,7 +127,7 @@ impl BootstrapServer {
 ignore_lifecycle!(BootstrapServer);
 
 impl NetworkActor for BootstrapServer {
-    type Deserialiser = ZSTSerialiser<CheckIn>;
+    type Deserialiser = ZstSerialiser<CheckIn>;
     type Message = CheckIn;
 
     fn receive(&mut self, source: Option<ActorPath>, _msg: Self::Message) -> Handled {

--- a/docs/src/distributed/networkstatusport.md
+++ b/docs/src/distributed/networkstatusport.md
@@ -8,9 +8,8 @@ Network, or make requests to the Network Layer.
 To subscribe to the import a component must implement `Require` for `NetworkStatusPort`. The system must be set-up with 
 a `NetworkingConfig` to enable Networking. When the component is instantiated it must be explicitly connected to the 
 `NetworkStatusPort`. `KompactSystem` exposes the convenience method 
-`connect_network_status_port<C>(&self, component: &Arc<Component<C>>)` to subscribe a component to the port, and may be 
-used as in the example below.
-
+`connect_network_status_port<C>(&self, required: &mut RequiredPort<NetworkStatusPort>)` to subscribe a component to the 
+port, and may be used as in the example below.
 ```
 # use kompact::prelude::*;
 # use kompact::net::net_test_helpers::NetworkStatusCounter;
@@ -20,8 +19,10 @@ cfg.system_components(DeadletterBox::new, {
     net_config.build()
 });
 let system = cfg.build().expect("KompactSystem");
-let c = system.create(NetworkStatusCounter::new);
-system.connect_network_status_port(&c);
+let status_counter = system.create(NetworkStatusCounter::new);
+status_counter.on_definition(|c|{
+  system.connect_network_status_port(&mut c.network_status_port);
+})
 ```
 
 ## Network Status Indications

--- a/docs/src/distributed/networkstatusport.md
+++ b/docs/src/distributed/networkstatusport.md
@@ -1,0 +1,52 @@
+# Network Status Port
+
+The `NetworkDispatcher` provides a `NetworkStatusPort` which any Component may use to subscribe to information about the 
+Network, or make requests to the Network Layer.
+
+## Using the Network Status Port
+
+To subscribe to the import a component must implement `Require` for `NetworkStatusPort`. The system must be set-up with 
+a `NetworkingConfig` to enable Networking. When the component is instantiated it must be explicitly connected to the 
+`NetworkStatusPort`. `KompactSystem` exposes the convenience method 
+`connect_network_status_port<C>(&self, component: &Arc<Component<C>>)` to subscribe a component to the port, and may be 
+used as in the example below.
+
+```
+# use kompact::prelude::*;
+# use kompact::net::net_test_helpers::NetworkStatusCounter;
+let mut cfg = KompactConfig::new();
+cfg.system_components(DeadletterBox::new, {
+    let net_config = NetworkConfig::new("127.0.0.1:0".parse().expect(""));
+    net_config.build()
+});
+let system = cfg.build().expect("KompactSystem");
+let c = system.create(NetworkStatusCounter::new);
+system.connect_network_status_port(&c);
+```
+
+## Network Status Indications
+
+`NetworkStatus` events are the `Indications` sent by the dispatcher to the subscribed components. 
+The Event is an `enum` with the following variants:
+
+* `ConnectionEstablished(SystemPath)` Indicates that a connection has been established to the remote system
+* `ConnectionLost(SystemPath)` Indicates that a connection has been lost to the remote system. The system will 
+  automatically try to recover the connection for a configurable amount of retries. The end of the automatic retries is 
+  signalled by a `ConnectionDropped` message.
+* `ConnectionDropped(SystemPath)` Indicates that a connection has been dropped and no more automatic retries to 
+  re-establish the connection will be attempted and all queued messages have been dropped.
+* `ConnectionClosed(SystemPath)` Indicates that a connection has been gracefully closed.
+
+The Networking layer distinguishes between gracefully closed connections and lost connections. 
+A lost connection will trigger reconnection attempts for a configurable amount of times, before it is completely dropped. 
+It will also retain outgoing messages for lost connections until the connection is dropped. 
+
+## Network Status Requests
+
+The `NetworkDispatcher` may respond to `NetworkStatusRequest` sent by Components onto the channel. 
+The event is an `enum` with the following variants:
+
+* `DisconnectSystem(SystemPath)` Request that the connection to the given system is closed gracefully. The 
+  `NetworkDispatcher`will immediately start a graceful shutdown of the channel if it is currently active.
+* `ConnectSystem(SystemPath)` Request that a connection is (re-)established to the given system. Sending this message is
+the only way a connection may be re-established between systems previously disconnected by a `DisconnectSystem` request.

--- a/docs/src/distributed/serialisation.md
+++ b/docs/src/distributed/serialisation.md
@@ -84,11 +84,11 @@ In our example, `CheckIn` is a *zero-sized type* (ZST), since we don't really ca
 {{#rustdoc_include ../../examples/src/bin/serialisation.rs:zstser}}
 ```
 
-We continue using the `SerialisationId` trait like we did for Serde, because we need to write id of the ZST not of the `ZSTSerialiser`, which can serialise and deserialise many different ZSTs.
+We continue using the `SerialisationId` trait like we did for Serde, because we need to write id of the ZST not of the `ZstSerialiser`, which can serialise and deserialise many different ZSTs.
 
 In order to create the correct type instance during deserialisation, we use the `Default` trait, which can be trivially derived for ZSTs.
 
-It is clear that this serialiser is basically trivial. We can use it by creating a pair of `Checkin` with a reference to our static instance `CHECK_IN_SER`, which simply specialises the `ZSTSerialiser` for `CheckIn`, as we did before: 
+It is clear that this serialiser is basically trivial. We can use it by creating a pair of `Checkin` with a reference to our static instance `CHECK_IN_SER`, which simply specialises the `ZstSerialiser` for `CheckIn`, as we did before: 
 
 ```rust,edition2018,no_run,noplaypen
 {{#rustdoc_include ../../examples/src/bin/serialisation.rs:checkin}}


### PR DESCRIPTION
* Added a NetworkStatusPort which components may connect to to receive NetworkStatusUpdate indications or send NetworkStatusRequests to the Dispatcher.
* Protocol to distinguish between gracefully closed channels and lost connections implemented.
* Docs page added for the NetworkStatusPort.
* Added public method `SystemPath::socket_address() -> SocketAddr` 
* Added public method `System::kill_system()` which kills a system without doing graceful shutdown of network channels.
* Components can send two requests on the NetworkStatusPort: `ConnectSystem(SystemPath)` which allows systems to initiate connections without sending messages to actors on the system, for set-up phases and network-overlay-management. And `DisconnectSystem(SystemPath)` which will initiate graceful disconnection between the systems, no messages are discarded and new messages sent between the systems will automatically reconnect the systems.

Please make sure these boxes are checked, before submitting a new PR.

- [✅ ] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [✅] You reference which issue is being closed in the PR text (if applicable)

## Issues

Closes #82 


(old discussion points)
> # This is a draft
> 
> I'd like to have a discussion on the API and naming here. 
> 
> 1. I'm not sure at all about using `SocketAddr`in the public interface. 
> 2. The CloseConnection() request immediately initiates a graceful shutdown of a connection and I'm not sure what should happen if there are enqueued messages, or future messages sent by either side. 
> 3. There are two indications which are undocumented and unused at the moment, I added them when I created the struct but I'm not sure if they'll be needed or if it's just bloat that probably won't be used . Maybe there's an event which should be added instead? 
> 4. MaxChannelsReached is one indication that is currently unused but this will be used soon. I'll make a separate PR for issue #83 soon.
> 5. I drew the graceful shutdown sequence [here](https://adamhass.github.io/close_channel_sequence.png) if anyone is interested in understanding it, I may have overengineered this part somewhat but now its there and is used to reliably distinguish between closed and lost connections.