### PR TITLE
Remove usages of expect_none

### DIFF
--- a/core/src/component/context.rs
+++ b/core/src/component/context.rs
@@ -183,19 +183,10 @@ where
             future,
             unblock_state,
         };
-        #[cfg(nightly)]
-        {
-            self.blocking_future
-                .replace(blocking_state)
-                .expect_none("Replacing a blocking future without completing it first is invalid!");
-        }
-        #[cfg(not(nightly))]
-        {
-            assert!(
-                self.blocking_future.replace(blocking_state).is_none(),
-                "Replacing a blocking future without completing it first is invalid!"
-            );
-        }
+        assert!(
+            self.blocking_future.replace(blocking_state).is_none(),
+            "Replacing a blocking future without completing it first is invalid!"
+        );
         let component = self.typed_component();
         component.set_blocking();
     }
@@ -230,19 +221,10 @@ where
         match blocking_state.future.run(&component) {
             BlockingRunResult::BlockOn(f) => {
                 blocking_state.future = f;
-                #[cfg(nightly)]
-                {
-                    self.blocking_future.replace(blocking_state).expect_none(
-                        "Replacing a blocking future without completing it first is invalid!",
-                    );
-                }
-                #[cfg(not(nightly))]
-                {
-                    assert!(
-                        self.blocking_future.replace(blocking_state).is_none(),
-                        "Replacing a blocking future without completing it first is invalid!"
-                    );
-                }
+                assert!(
+                    self.blocking_future.replace(blocking_state).is_none(),
+                    "Replacing a blocking future without completing it first is invalid!"
+                );
                 SchedulingDecision::Blocked
             }
             BlockingRunResult::Unblock => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,7 +69,6 @@
 #![allow(clippy::match_ref_pats)]
 #![allow(clippy::new_without_default)]
 #![cfg_attr(nightly, feature(never_type))]
-#![cfg_attr(nightly, feature(option_expect_none))]
 #![cfg_attr(nightly, feature(async_closure))]
 #![cfg_attr(nightly, feature(unsized_fn_params))] // requires nightly > 2020-10-29
 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Rust ppl decided not to stabilise this: https://github.com/rust-lang/rust/issues/62633#issuecomment-777009499

## Other Changes

- Remove nightly-only usages of `Option::expect_none` in favour of the more verbose `assert!(Option::is_none())`
