### PR TITLE
New match_deser macro implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4b29f4b9bb94bf267d57269fd0706d343a160937108e9619fe380645428abb"
+
+[[package]]
 name = "dynamic-benches"
 version = "0.1.0"
 dependencies = [
@@ -1180,6 +1186,7 @@ dependencies = [
  "protobuf",
  "rustc-hash",
  "rustc_version",
+ "rustversion",
  "serde",
  "slog",
  "slog-async",
@@ -2227,6 +2234,7 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99471a206425fba51842a9186315f32d91c56eadc21ea4c21f847b59cf778f8b"
 dependencies = [
+ "dissimilar",
  "glob",
  "lazy_static",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
@@ -154,7 +154,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -453,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -474,8 +474,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.2",
- "crossbeam-utils 0.8.2",
+ "crossbeam-epoch 0.9.3",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -495,14 +495,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
- "loom",
  "memoffset 0.6.1",
  "scopeguard",
 ]
@@ -550,14 +549,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -924,19 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1275,17 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if 1.0.0",
- "generator",
- "scoped-tls",
-]
-
-[[package]]
 name = "lru"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1451,9 +1425,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
+checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
 
 [[package]]
 name = "oncemutex"
@@ -1759,7 +1733,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",
 ]
@@ -1872,12 +1846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
 dependencies = [
  "itoa",
  "ryu",
@@ -2398,9 +2366,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2408,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2423,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2435,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2445,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2458,15 +2426,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "62eaa19b325e1b3dc2f7b9b6de544dd536619e3dcf986fc391b2c643f10d68c0"
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -807,9 +807,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -954,6 +954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1180,6 +1186,7 @@ dependencies = [
  "slog-term",
  "synchronoise",
  "tempfile",
+ "trybuild",
  "uuid",
 ]
 
@@ -1334,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
 dependencies = [
  "libc",
  "log",
@@ -1357,12 +1364,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "socket2",
 ]
 
 [[package]]
@@ -1631,7 +1638,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -1652,7 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1666,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -1688,7 +1695,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1736,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1920,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+checksum = "65e65d6a9f13cd78f361ea5a2cf53a45d67cdda421ba0316b9be101560f3d207"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -2058,6 +2065,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,18 +2103,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2159,6 +2175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2219,20 @@ dependencies = [
  "smallvec",
  "thiserror",
  "trust-dns-proto",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99471a206425fba51842a9186315f32d91c56eadc21ea4c21f847b59cf778f8b"
+dependencies = [
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -2251,9 +2290,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -77,7 +77,8 @@ iovec 							= "0.1.1" # Match MIOs Version
 tempfile 		= "3"
 serde 			= {version = "1.0", features = ["derive"]}
 once_cell 		= "1.4"
-trybuild 		= "1.0"
+rustversion 	= "1.0"
+trybuild 		= {version = "1.0", features = ["diff"] }
 
 [build-dependencies]
 rustc_version 	= "0.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -77,6 +77,7 @@ iovec 							= "0.1.1" # Match MIOs Version
 tempfile 		= "3"
 serde 			= {version = "1.0", features = ["derive"]}
 once_cell 		= "1.4"
+trybuild 		= "1.0"
 
 [build-dependencies]
 rustc_version 	= "0.2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -72,6 +72,9 @@
 #![cfg_attr(nightly, feature(async_closure))]
 #![cfg_attr(nightly, feature(unsized_fn_params))] // requires nightly > 2020-10-29
 
+// TODO: Remove
+//#![feature(trace_macros)]
+
 #[cfg(feature = "thread_pinning")]
 pub use core_affinity::{get_core_ids, CoreId};
 
@@ -375,6 +378,9 @@ mod test_helpers {
         path::{Path, PathBuf},
     };
     use tempfile::TempDir;
+
+    /// A quick test path to create an [ActorPath](ActorPath) with
+    pub const TEST_PATH: &str = "local://127.0.0.1:0/test_actor";
 
     // liberally borrowed from https://andrewra.dev/2019/03/01/testing-in-rust-temporary-files/
     pub struct Fixture {

--- a/core/src/net/buffers/mod.rs
+++ b/core/src/net/buffers/mod.rs
@@ -41,7 +41,7 @@ impl BufferConfig {
         let mut buffer_config = BufferConfig::default();
         if let Some(chunk_size) = config["buffer_config"]["chunk_size"].as_bytes() {
             buffer_config.chunk_size = chunk_size
-                .ceil_as_checked()
+                .ceil_checked_cast()
                 .expect("Invalid byte number for chunk_size");
         }
         if let Some(initial_chunk_count) = config["buffer_config"]["initial_chunk_count"].as_i64() {
@@ -56,7 +56,7 @@ impl BufferConfig {
             config["buffer_config"]["encode_min_remaining"].as_bytes()
         {
             buffer_config.encode_buf_min_free_space = encode_min_remaining
-                .ceil_as_checked()
+                .ceil_checked_cast()
                 .expect("Invalid byte number for encode_min_remaining");
         }
         buffer_config.validate();

--- a/core/src/net/buffers/mod.rs
+++ b/core/src/net/buffers/mod.rs
@@ -38,8 +38,8 @@ impl BufferConfig {
     /// if it fails to read from the config.
     pub fn from_config(config: &Hocon) -> Self {
         let mut buffer_config = BufferConfig::default();
-        if let Some(chunk_size) = config["buffer_config"]["chunk_size"].as_i64() {
-            buffer_config.chunk_size = chunk_size as usize;
+        if let Some(chunk_size) = config["buffer_config"]["chunk_size"].as_bytes() {
+            buffer_config.chunk_size = chunk_size.ceil() as usize;
         }
         if let Some(initial_chunk_count) = config["buffer_config"]["initial_chunk_count"].as_i64() {
             buffer_config.initial_chunk_count = initial_chunk_count as usize;
@@ -47,9 +47,9 @@ impl BufferConfig {
         if let Some(max_chunk_count) = config["buffer_config"]["max_chunk_count"].as_i64() {
             buffer_config.max_chunk_count = max_chunk_count as usize;
         }
-        if let Some(encode_min_remaining) = config["buffer_config"]["encode_min_remaining"].as_i64()
+        if let Some(encode_min_remaining) = config["buffer_config"]["encode_min_remaining"].as_bytes()
         {
-            buffer_config.encode_buf_min_free_space = encode_min_remaining as usize;
+            buffer_config.encode_buf_min_free_space = encode_min_remaining.ceil() as usize;
         }
         buffer_config.validate();
         buffer_config
@@ -455,11 +455,11 @@ mod tests {
         cfg.load_config_str(
             r#"{
                 buffer_config {
-                    chunk_size: 256,
+                    chunk_size: "256B",
                     initial_chunk_count: 3,
                     max_chunk_count: 4,
-                    encode_min_remaining: 20,
-                    }
+                    encode_min_remaining: "20B",
+                }
                 }"#,
         );
         cfg.system_components(DeadletterBox::new, {

--- a/core/src/net/buffers/mod.rs
+++ b/core/src/net/buffers/mod.rs
@@ -47,7 +47,8 @@ impl BufferConfig {
         if let Some(max_chunk_count) = config["buffer_config"]["max_chunk_count"].as_i64() {
             buffer_config.max_chunk_count = max_chunk_count as usize;
         }
-        if let Some(encode_min_remaining) = config["buffer_config"]["encode_min_remaining"].as_bytes()
+        if let Some(encode_min_remaining) =
+            config["buffer_config"]["encode_min_remaining"].as_bytes()
         {
             buffer_config.encode_buf_min_free_space = encode_min_remaining.ceil() as usize;
         }

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -606,20 +606,22 @@ pub mod net_test_helpers {
 
         fn receive_network(&mut self, msg: NetMessage) -> Handled {
             let sender = msg.sender;
-            match_deser! {msg.data; {
-                ping: PingMsg [PingPongSer] => {
-                    debug!(self.ctx.log(), "Got msg {:?} from {}", ping, sender);
-                    let pong = PongMsg { i: ping.i };
-                    if self.eager {
-                        sender
-                            .tell_serialised(pong, self)
-                            .expect("PongMsg should serialise");
-                    } else {
-                        sender.tell(pong, self);
-                    }
-                },
-                !Err(e) => error!(self.ctx.log(), "Error deserialising PingMsg: {:?}", e),
-            }}
+            match_deser! {
+                (msg.data) {
+                    msg(ping): PingMsg [using PingPongSer] => {
+                        debug!(self.ctx.log(), "Got msg {:?} from {}", ping, sender);
+                        let pong = PongMsg { i: ping.i };
+                        if self.eager {
+                            sender
+                                .tell_serialised(pong, self)
+                                .expect("PongMsg should serialise");
+                        } else {
+                            sender.tell(pong, self);
+                        }
+                    },
+                    err(e) => error!(self.ctx.log(), "Error deserialising PingMsg: {:?}", e),
+                }
+            }
             Handled::Ok
         }
     }
@@ -1067,21 +1069,23 @@ pub mod net_test_helpers {
 
         fn receive_network(&mut self, msg: NetMessage) -> Handled {
             let sender = msg.sender;
-            match_deser! {msg.data; {
-                ping: BigPingMsg [BigPingPongSer] => {
-                    debug!(self.ctx.log(), "Got msg {:?} from {}", ping, sender);
-                    ping.validate();
-                    let pong = BigPongMsg::new(ping.i, ping.data.len());
-                    if self.eager {
-                        sender
-                            .tell_serialised(pong, self)
-                            .expect("BigPongMsg should serialise");
-                    } else {
-                        sender.tell(pong, self);
-                    }
-                },
-                !Err(e) => error!(self.ctx.log(), "Error deserialising BigPingMsg: {:?}", e),
-            }}
+            match_deser! {
+                (msg.data) {
+                    msg(ping): BigPingMsg [using BigPingPongSer] => {
+                        debug!(self.ctx.log(), "Got msg {:?} from {}", ping, sender);
+                        ping.validate();
+                        let pong = BigPongMsg::new(ping.i, ping.data.len());
+                        if self.eager {
+                            sender
+                                .tell_serialised(pong, self)
+                                .expect("BigPongMsg should serialise");
+                        } else {
+                            sender.tell(pong, self);
+                        }
+                    },
+                    err(e) => error!(self.ctx.log(), "Error deserialising BigPingMsg: {:?}", e),
+                }
+            }
             Handled::Ok
         }
     }

--- a/core/src/routing/mod.rs
+++ b/core/src/routing/mod.rs
@@ -70,10 +70,12 @@ pub(crate) mod test_helpers {
         }
 
         fn receive_network(&mut self, msg: NetMessage) -> Handled {
-            match_deser!(msg; {
-                _count_me: CountMe [CountMe] => self.count += 1,
-                !Err(e) => error!(self.log(), "Received something else: {:?}", e),
-            });
+            match_deser! {
+                msg {
+                    msg(_count_me): CountMe => self.count += 1,
+                    err(e) => error!(self.log(), "Received something else: {:?}", e),
+                }
+            };
             Handled::Ok
         }
     }

--- a/core/src/utils/checked_casts.rs
+++ b/core/src/utils/checked_casts.rs
@@ -43,23 +43,23 @@ pub trait CheckedIntegerCasts<Target> {
     ///
     /// Returns errors if there is no equivalent target value
     /// or the source value is out of range for the target.
-    fn as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    fn checked_cast(self) -> Result<Target, ConvertToIntError<Self>>
     where
         Self: Sized;
 
     /// If the cast involves rounding, round up.
-    fn ceil_as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    fn ceil_checked_cast(self) -> Result<Target, ConvertToIntError<Self>>
     where
         Self: Sized;
 
     /// If the cast involves rounding, round down.
-    fn floor_as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    fn floor_checked_cast(self) -> Result<Target, ConvertToIntError<Self>>
     where
         Self: Sized;
 }
 
 impl CheckedIntegerCasts<usize> for f64 {
-    fn as_checked(self) -> Result<usize, ConvertToIntError<Self>> {
+    fn checked_cast(self) -> Result<usize, ConvertToIntError<Self>> {
         if self.is_nan() || self.is_infinite() {
             return Err(ConvertToIntError::illegal_value(self));
         }
@@ -69,18 +69,18 @@ impl CheckedIntegerCasts<usize> for f64 {
         Ok(self as usize)
     }
 
-    fn ceil_as_checked(self) -> Result<usize, ConvertToIntError<Self>>
+    fn ceil_checked_cast(self) -> Result<usize, ConvertToIntError<Self>>
     where
         Self: Sized,
     {
-        self.ceil().as_checked()
+        self.ceil().checked_cast()
     }
 
-    fn floor_as_checked(self) -> Result<usize, ConvertToIntError<Self>>
+    fn floor_checked_cast(self) -> Result<usize, ConvertToIntError<Self>>
     where
         Self: Sized,
     {
-        self.floor().as_checked()
+        self.floor().checked_cast()
     }
 }
 
@@ -90,20 +90,20 @@ mod tests {
 
     #[test]
     fn check_f64_casts() {
-        assert_eq!(1usize, 1.0f64.as_checked().unwrap());
-        assert_eq!(1usize, 0.5f64.ceil_as_checked().unwrap());
-        assert_eq!(0usize, 0.5f64.floor_as_checked().unwrap());
+        assert_eq!(1usize, 1.0f64.checked_cast().unwrap());
+        assert_eq!(1usize, 0.5f64.ceil_checked_cast().unwrap());
+        assert_eq!(0usize, 0.5f64.floor_checked_cast().unwrap());
 
-        assert_eq!(0usize, 0.0f64.as_checked().unwrap());
-        assert_eq!(0usize, (-0.0f64).as_checked().unwrap());
+        assert_eq!(0usize, 0.0f64.checked_cast().unwrap());
+        assert_eq!(0usize, (-0.0f64).checked_cast().unwrap());
 
-        assert_eq!(usize::MAX, (usize::MAX as f64).as_checked().unwrap());
+        assert_eq!(usize::MAX, (usize::MAX as f64).checked_cast().unwrap());
 
-        assert!((f64::NAN).as_checked().is_err());
-        assert!((f64::INFINITY).as_checked().is_err());
-        assert!((f64::NEG_INFINITY).as_checked().is_err());
-        //assert!((usize::MAX as f64 + 1.0).as_checked().is_err());
-        assert!((f64::MAX).as_checked().is_err());
-        assert!((-1.0f64).as_checked().is_err());
+        assert!((f64::NAN).checked_cast().is_err());
+        assert!((f64::INFINITY).checked_cast().is_err());
+        assert!((f64::NEG_INFINITY).checked_cast().is_err());
+        //assert!((usize::MAX as f64 + 1.0).checked_cast().is_err());
+        assert!((f64::MAX).checked_cast().is_err());
+        assert!((-1.0f64).checked_cast().is_err());
     }
 }

--- a/core/src/utils/checked_casts.rs
+++ b/core/src/utils/checked_casts.rs
@@ -1,0 +1,109 @@
+use std::fmt;
+
+const ILLEGAL_VALUE_DESC: &str = "source value was illegal for the target type";
+const OUT_OF_RANGE_DESC: &str = "source value was out of range for the target type";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ConvertToIntError<N> {
+    original: N,
+    description: &'static str,
+}
+
+impl<N> ConvertToIntError<N> {
+    fn illegal_value(original: N) -> Self {
+        ConvertToIntError {
+            original,
+            description: ILLEGAL_VALUE_DESC,
+        }
+    }
+
+    fn out_of_range(original: N) -> Self {
+        ConvertToIntError {
+            original,
+            description: OUT_OF_RANGE_DESC,
+        }
+    }
+}
+
+impl<N: fmt::Display> fmt::Display for ConvertToIntError<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Conversion of {} was unsuccessful; {}",
+            self.original, self.description
+        )
+    }
+}
+
+/// Casting safely to integers
+///
+/// Prefer using [TryFrom](std::convert::TryFrom) where available.
+pub trait CheckedIntegerCasts<Target> {
+    /// Cast to the nearest target value
+    ///
+    /// Returns errors if there is no equivalent target value
+    /// or the source value is out of range for the target.
+    fn as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    where
+        Self: Sized;
+
+    /// If the cast involves rounding, round up.
+    fn ceil_as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    where
+        Self: Sized;
+
+    /// If the cast involves rounding, round down.
+    fn floor_as_checked(self) -> Result<Target, ConvertToIntError<Self>>
+    where
+        Self: Sized;
+}
+
+impl CheckedIntegerCasts<usize> for f64 {
+    fn as_checked(self) -> Result<usize, ConvertToIntError<Self>> {
+        if self.is_nan() || self.is_infinite() {
+            return Err(ConvertToIntError::illegal_value(self));
+        }
+        if (self.is_sign_negative() && self != -0.0f64) || (self > usize::MAX as f64) {
+            return Err(ConvertToIntError::out_of_range(self));
+        }
+        Ok(self as usize)
+    }
+
+    fn ceil_as_checked(self) -> Result<usize, ConvertToIntError<Self>>
+    where
+        Self: Sized,
+    {
+        self.ceil().as_checked()
+    }
+
+    fn floor_as_checked(self) -> Result<usize, ConvertToIntError<Self>>
+    where
+        Self: Sized,
+    {
+        self.floor().as_checked()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_f64_casts() {
+        assert_eq!(1usize, 1.0f64.as_checked().unwrap());
+        assert_eq!(1usize, 0.5f64.ceil_as_checked().unwrap());
+        assert_eq!(0usize, 0.5f64.floor_as_checked().unwrap());
+
+        assert_eq!(0usize, 0.0f64.as_checked().unwrap());
+        assert_eq!(0usize, (-0.0f64).as_checked().unwrap());
+
+        assert_eq!(usize::MAX, (usize::MAX as f64).as_checked().unwrap());
+
+        assert!((f64::NAN).as_checked().is_err());
+        assert!((f64::INFINITY).as_checked().is_err());
+        assert!((f64::NEG_INFINITY).as_checked().is_err());
+        //assert!((usize::MAX as f64 + 1.0).as_checked().is_err());
+        assert!((f64::MAX).as_checked().is_err());
+        assert!((-1.0f64).as_checked().is_err());
+    }
+}

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -16,6 +16,7 @@ use super::*;
 
 mod ask;
 pub use ask::*;
+pub(crate) mod checked_casts;
 mod iter_extras;
 pub use iter_extras::*;
 mod macros;

--- a/core/tests/compile-fail/match_deser_tests.rs
+++ b/core/tests/compile-fail/match_deser_tests.rs
@@ -1,0 +1,31 @@
+use kompact::prelude::*;
+
+fn match_msg(msg: NetMessage) -> () {
+	match_deser! {
+		msg {
+    		msg(_res) [using String] => (), //~ ERROR: Must specify a deserialisation target type
+    	}
+    };
+    match_deser! {
+		msg {
+    		nsg(_res): String => (), //~ ERROR: Illegal case `nsg`. Allowed values: [`msg`, `err`, `default`]
+    	}
+    };
+    match_deser! {
+		msg {
+    		my_msg: String => (), //~ ERROR: Illegal `match_deser!` item(s). See docs for example of legal items.  Offending item(s): my_msg : String => ()
+    	}
+    };
+    match_deser! {
+		msg {
+    		my_msg: String => () //~ ERROR: Illegal `match_deser!` items(s). See docs for example of legal items.  Offending item(s): my_msg : String => ()
+    	}
+    };
+    match_deser!(msg; {
+    	my_msg: String => (), //~ ERROR: You are using an old `match_deser!` format. See docs for the new format.
+    })
+}
+
+fn main() { 
+	// unused 
+}

--- a/core/tests/compile-fail/match_deser_tests.stderr
+++ b/core/tests/compile-fail/match_deser_tests.stderr
@@ -1,0 +1,57 @@
+error: Must specify a deserialisation target type
+ --> $DIR/match_deser_tests.rs:4:2
+  |
+4 | /     match_deser! {
+5 | |         msg {
+6 | |             msg(_res) [using String] => (), //~ ERROR: Must specify a deserialisation target type
+7 | |         }
+8 | |     };
+  | |______^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Illegal case `nsg`. Allowed values: [`msg`, `err`, `default`]
+  --> $DIR/match_deser_tests.rs:9:5
+   |
+9  | /     match_deser! {
+10 | |         msg {
+11 | |             nsg(_res): String => (), //~ ERROR: Illegal case `nsg`. Allowed values: [`msg`, `err`, `default`]
+12 | |         }
+13 | |     };
+   | |______^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Illegal `match_deser!` item(s). See docs for example of legal items. Offending item(s): my_msg : String => (),
+  --> $DIR/match_deser_tests.rs:14:5
+   |
+14 | /     match_deser! {
+15 | |         msg {
+16 | |             my_msg: String => (), //~ ERROR: Illegal `match_deser!` item(s). See docs for example of legal items.  Offending item(s): my_...
+17 | |         }
+18 | |     };
+   | |______^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Illegal `match_deser!` item(s). See docs for example of legal items. Offending item(s): my_msg : String => ()
+  --> $DIR/match_deser_tests.rs:19:5
+   |
+19 | /     match_deser! {
+20 | |         msg {
+21 | |             my_msg: String => () //~ ERROR: Illegal `match_deser!` items(s). See docs for example of legal items.  Offending item(s): my_...
+22 | |         }
+23 | |     };
+   | |______^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: You are using an old `match_deser!` format. See docs for the new format.
+  --> $DIR/match_deser_tests.rs:24:5
+   |
+24 | /     match_deser!(msg; {
+25 | |         my_msg: String => (), //~ ERROR: You are using an old `match_deser!` format. See docs for the new format.
+26 | |     })
+   | |______^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/tests/macro_compile_tests.rs
+++ b/core/tests/macro_compile_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_test() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+}

--- a/core/tests/macro_compile_tests.rs
+++ b/core/tests/macro_compile_tests.rs
@@ -1,4 +1,7 @@
-#[test]
+// Stable formats the output differently
+//#[rustversion::attr(not(nightly), ignore)]
+//#[test]
+#[rustversion::attr(nightly, test)]
 fn compile_test() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");

--- a/docs/examples/src/bin/bootstrapping.rs
+++ b/docs/examples/src/bin/bootstrapping.rs
@@ -185,8 +185,7 @@ impl Actor for EventualLeaderElector {
                 msg(_heartbeat): Heartbeat [using Serde] => {
                     self.candidates.insert(sender);
                 },
-                msg(update): UpdateProcesses [using Serde] => {
-                    let UpdateProcesses(processes) = update;
+                msg(UpdateProcesses(processes)): UpdateProcesses [using Serde] => {
                     info!(
                         self.log(),
                         "Received new process set with {} processes",

--- a/docs/examples/src/bin/bootstrapping.rs
+++ b/docs/examples/src/bin/bootstrapping.rs
@@ -180,20 +180,22 @@ impl Actor for EventualLeaderElector {
     fn receive_network(&mut self, msg: NetMessage) -> Handled {
         let sender = msg.sender;
 
-        match_deser!(msg.data; {
-            _heartbeat: Heartbeat [Serde] => {
-                self.candidates.insert(sender);
-            },
-            update: UpdateProcesses [Serde] => {
-                let UpdateProcesses(processes) = update;
-                info!(
-                    self.log(),
-                    "Received new process set with {} processes",
-                    processes.len()
-                );
-                self.processes = processes.into_boxed_slice();
-            },
-        });
+        match_deser! {
+            (msg.data) {
+                msg(_heartbeat): Heartbeat [using Serde] => {
+                    self.candidates.insert(sender);
+                },
+                msg(update): UpdateProcesses [using Serde] => {
+                    let UpdateProcesses(processes) = update;
+                    info!(
+                        self.log(),
+                        "Received new process set with {} processes",
+                        processes.len()
+                    );
+                    self.processes = processes.into_boxed_slice();
+                },
+            }
+        };
         Handled::Ok
     }
 }

--- a/docs/examples/src/bin/serialisation.rs
+++ b/docs/examples/src/bin/serialisation.rs
@@ -266,20 +266,22 @@ impl Actor for EventualLeaderElector {
     fn receive_network(&mut self, msg: NetMessage) -> Handled {
         let sender = msg.sender;
 
-        match_deser!(msg.data; {
-            _heartbeat: Heartbeat [Serde] => {
-                self.candidates.insert(sender);
-            },
-            update: UpdateProcesses [UpdateProcesses] => {
-                let UpdateProcesses(processes) = update;
-                info!(
-                    self.log(),
-                    "Received new process set with {} processes",
-                    processes.len()
-                );
-                self.processes = processes.into_boxed_slice();
-            },
-        });
+        match_deser! {
+            (msg.data) {
+                msg(_heartbeat): Heartbeat [using Serde] => {
+                    self.candidates.insert(sender);
+                },
+                msg(update): UpdateProcesses => {
+                    let UpdateProcesses(processes) = update;
+                    info!(
+                        self.log(),
+                        "Received new process set with {} processes",
+                        processes.len()
+                    );
+                    self.processes = processes.into_boxed_slice();
+                },
+            }
+        }
         Handled::Ok
     }
     // ANCHOR_END: receive_network

--- a/docs/src/distributed/basiccommunication.md
+++ b/docs/src/distributed/basiccommunication.md
@@ -63,7 +63,7 @@ omega {
 }
 ```
 
-And the we can load it and start the initial timeout in the `on_start` handler as before:
+And then we can load it and start the initial timeout in the `on_start` handler as before:
 
 ```rust,edition2018,no_run,noplaypen
 {{#rustdoc_include ../../examples/src/bin/leader_election.rs:lifecycle}}

--- a/docs/src/distributed/namedservices.md
+++ b/docs/src/distributed/namedservices.md
@@ -49,7 +49,28 @@ match msg.ser_id() {
 }
 ```
 
-Kompact provides the `match_deser!` macro to generate code like the above, since this is very common behaviour and writing it manually gets somewhat tedious eventually. The syntax for each different message case in the macro is basically `variable_name: MessageType [DeserialiserType] => <body>,`. Using this, our new actor implementation becomes the following:
+Kompact provides the `match_deser!` macro to generate code like the above, since this is very common behaviour and writing it manually gets somewhat tedious eventually. The overall syntax for the macro is:
+
+```
+match_deser! {
+	(<message expression>) {
+		<message case 1>,
+		<message case 2>,
+		...
+	}
+}
+```
+
+Here `<message expression>` is an expression that gives the message (data) to be deserialised. If the expression is simply an identifier like `msg` then the parenthesis may be elided.
+The syntax for each different message case in the macro is basically:
+
+```
+msg(variable_name): MessageType [using DeserialiserType] => <body>
+```
+
+For cases where `MessageType = DeserialiserType` the `[using DeserialiserType]` block can be elided. There are also default and error branches available for the macro, an example of which can be see in the [API docs](https://docs.rs/kompact/latest/kompact/macro.match_deser.html). It is also possible to immediately destructure the deserialised message by replacing `variable_name` with a pattern, as can be seen in the case of `UpdateProcesses` below.
+
+Using this macro, our new actor implementation becomes the following:
 
 ```rust,edition2018,no_run,noplaypen
 {{#rustdoc_include ../../examples/src/bin/bootstrapping.rs:actor}}

--- a/docs/src/distributed/networkbuffers.md
+++ b/docs/src/distributed/networkbuffers.md
@@ -1,30 +1,30 @@
 # Network Buffers
 
-Kompact uses a BufferPool system to serialize network messages. This section will describe the BufferPools briefly and how they can be configured with different parameters.
+Kompact uses a BufferPool system to serialize network messages. This section describes the BufferPools briefly and how they can be configured with different parameters.
 
 Before we begin describing the Network Buffers we remind the reader that there are two different methods for sending messages over the network in Kompact:   
 1. **Lazy serialisation** `dst.tell(msg: M, from: S);`
-2. **Eager serialisation** `dst.tell_serialised(msg: M, from: &self)?;`
+2. **Eager serialisation** `dst.tell_serialised(msg: M, from: &self);`
 
-With lazy serialisation the Actor moves the data to the heap, and transfers it unserialised to the `NetworkDispatcher`, which later serialises the message into its (the `NetworkDispatcher's`) own buffers.   
-Eager serialisation serialises the data immediately into the Actors Buffers, and then transfers ownership of the serialised the data to the `NetworkDispatcher`.
+With lazy serialisation the Actor moves the data to the heap, and transfers it unserialised to the `NetworkDispatcher`, which later serialises the message into its (the `NetworkDispatcher`'s) own buffers.   
+Eager serialisation serialises the data immediately into the Actor's buffers, and then transfers ownership of the serialised the data to the `NetworkDispatcher`.
 
-## How the BufferPools work
+## How the Buffer Pools work
 
-### BufferPool locations
-In a Kompact system where many actors use eager serialisation there will be many `BufferPools`. Ìf the actors in the system only use lazy serialisation there will be two pools, one used by the `NetworkDispatcher` for serialising outbound data, and one used by the `NetworkThread` for receiving incoming data.
+### Buffer Pool locations
+In a Kompact system where many actors use eager serialisation there will be many `BufferPool` instances. Ìf the actors in the system only use lazy serialisation there will be two pools, one used by the `NetworkDispatcher` for serialising outbound data, and one used by the `NetworkThread` for receiving incoming data.
 
-### BufferPool, BufferChunk, ChunkLease
-Each `BufferPool` (pool) consists of more than one `BufferChunks` (chunks). A chunk is the concrete memory area used for serialising data into. There may be many messages serialised into a single chunk, and discrete slices of the chunks (i.e. individual messages) can be extracted and sent to other threads/actors through the smart-pointer `ChunkLease` (lease). When a chunk runs out of space it will be locked and returned to the pool. If and only if all outstanding leases created from a chunk have been dropped may the chunk be unlocked and reused, or deallocated.
+### BufferPool, BufferChunk, and ChunkLease
+Each `BufferPool` (pool) consists of more than one `BufferChunk` (chunks). A chunk is the concrete memory area used for serialising data into. There may be many messages serialised into a single chunk, and discrete slices of the chunks (i.e. individual messages) can be extracted and sent to other threads/actors through the smart-pointer `ChunkLease` (lease). When a chunk runs out of space it will be locked and returned to the pool. If and only if all outstanding leases created from a chunk have been dropped may the chunk be unlocked and reused, or deallocated.
 
 When a pool is created it will pre-allocate a configurable amount of chunks, and will attempt to reuse those as long as possible, and only when it needs to will it allocate more chunks, up to a configurable maximum number of chunks. 
 
 **Note: In the current version, behaviour is unstable when a pool runs out of chunks and is unable to allocate more and will often cause a panic, similar to out-of-memory exception.** 
 
-### BufferPool interface
+### The BufferPool interface
 Actors access their pool through the `EncodeBuffer` wrapper which maintains a single active chunk at a time, and automatically swaps the active buffer with the local `BufferPool` when necessary.  
 
-The method `tell_serialised(msg, &self)?;` automatically uses the `EncodeBuffer` interface such that users of Kompact do not need to use the interfaces of the pool (why the method requires the `self` reference). Currently, a serialised message may not be greater than the size of the `BufferChunk`.  
+The method `tell_serialised(msg, &self)` automatically uses the `EncodeBuffer` interface such that users of Kompact do not need to use the interfaces of the pool (which is why the method requires a `self` reference). 
 
 ### BufferPool initialization
 Actors initialize their local buffers automatically when the first invocation of `tell_serialised(...)` occurs. If an Actor never invokes the method it will not allocate any buffers.  
@@ -36,10 +36,10 @@ An actor may call the initialization method through the call `self.ctx.borrow().
 ### Parameters
 There are four configurable parameters in the BufferConfig:
 
-1. `chunk_size`: the size (in bytes) of the `BufferChunks`, and thereby dictating the maximum serialised message size. Default value is 128KB.
-2. `initial_chunk_count`: how many `BufferChunks` the `BufferPool` will pre-allocate. Default value is 2.
-3. `max_chunk_count`: the maximum number of `BufferChunks` the `BufferPool` may have allocated simultaneously. Default value is 1000.
-4. `encode_buf_min_free_space`: When an Actor begins serialising a message the `EncodeBuffer` will compare how much space (in bytes) is left in the active chunk and compare it to this parameter, if there is less free space the active chunk will be replaced with a new one from the pool before continuing the serialisation. Default value is 64.
+1. `chunk_size`: The size (in bytes) of the `BufferChunks`. Default value is 128KB.
+2. `initial_chunk_count`: How many `BufferChunks` the `BufferPool` will pre-allocate. Default value is 2.
+3. `max_chunk_count`: The maximum number of `BufferChunks` the `BufferPool` may have allocated simultaneously. Default value is 1000.
+4. `encode_buf_min_free_space`: When an Actor begins serialising a message the `EncodeBuffer` will compare how much space (in bytes) is left in the active chunk and compare it to this parameter, if there is less free space the active chunk will be replaced with a new one from the pool before continuing the serialisation. Default value is 64 bytes.
 
 ### Configuring the Buffers
 
@@ -53,7 +53,7 @@ impl ComponentLifecycle for CustomBufferConfigActor {
         buffer_config.encode_buf_min_free_space(128);
         buffer_config.max_chunk_count(5);
         buffer_config.initial_chunk_count(4);
-        buffer_config.chunk_size(256000);
+        buffer_config.chunk_size(256*1024);
         
         self.ctx.borrow().init_buffers(Some(buffer_config), None);
         Handled::Ok
@@ -69,11 +69,11 @@ let mut cfg = KompactConfig::new();
 cfg.load_config_str(
     r#"{
         buffer_config {
-            chunk_size: 256000,
+            chunk_size: "256KB",
             initial_chunk_count: 3,
             max_chunk_count: 4,
-            encode_min_remaining: 20,
-            }
+            encode_min_remaining: "20B",
+        }
         }"#,
 );
 ...
@@ -103,10 +103,10 @@ let system = cfg.build().expect("KompactSystem");
 
 #### BufferConfig Validation
 
-`BufferConfig` implements the method `validate()` which causes a panic if any of the parameters are valid. It is invoked whenever a `BufferPool` is created from the given configuration. The validation checks the following conditions hold true:   
-`chunk_size` > `encode_buf_min_free_space`   
-`chunk_size` > 127   
-`max_chunk_count` >= `initial_chunk_count`
+`BufferConfig` implements the method `validate()` which causes a panic if the set of parameters is invalid. It is invoked whenever a `BufferPool` is created from the given configuration. The validation checks that the following conditions hold true:   
+- `chunk_size > encode_buf_min_free_space`   
+- `chunk_size > 127`
+- `max_chunk_count >= initial_chunk_count`
 
 - - - 
-[^1]: The method `init_buffers(...)` takes two `Option` arguments, of which the second argument has not been covered. The second argument allows users of Kompact to specify a `CustomAllocator`, an untested experimental feature which is left undocumented for now. 
+[^1]: The method `init_buffers(...)` takes two `Option` arguments, of which the second argument has not been covered. The second argument allows users of Kompact to specify a `CustomAllocator`: a poorly tested, experimental feature which is left undocumented for the time being. 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Fixes #37.

## Breaking Changes

- New syntax for the `match_deser` macro

### Example

For some `msg: NetMessage`.

Old:
```rust
match_deser! { msg; {
    res: MsgA [MsgA] => EitherAOrB::A(res),
    res: MsgB [BSer] => EitherAOrB::B(res),
    !Err(_e) => panic!("test panic please ignore"),
    _ => unimplemented!("Should be either MsgA or MsgB!"),
}}
```
Becomes New:
```rust
match_deser! {
    msg {
       msg(res): MsgA => EitherAOrB::A(res),
       msg(res): MsgB [using BSer] => EitherAOrB::B(res),
       err(_e) => panic!("test panic please ignore"),
       default(_) => unimplemented!("Should be either MsgA or MsgB!"),
    }
}
```

## Other Changes

- Reading buffer sizes from HOCON now allows unit specifications, e.g. "256KB".

## Status

- [x] Macro implementation
- [x] Feedback from @adamhass and @haraldng (and whoever else has strong opinions about the syntax of the macro)
- [x] Macro error handling (i.e. better error messages)
- [x] Double check doc text and fix if necessary
