### PR TITLE
Complete promises without providing a value

### DIFF
--- a/core/src/default_components.rs
+++ b/core/src/default_components.rs
@@ -197,7 +197,7 @@ impl ComponentLifecycle for DeadletterBox {
     fn on_start(&mut self) -> Handled {
         debug!(self.ctx.log(), "Starting DeadletterBox");
         if let Some(promise) = self.notify_ready.take() {
-            promise.fulfil(()).unwrap_or(())
+            promise.complete().unwrap_or(())
         }
         Handled::Ok
     }
@@ -272,7 +272,7 @@ impl ComponentLifecycle for LocalDispatcher {
     fn on_start(&mut self) -> Handled {
         debug!(self.ctx.log(), "Starting LocalDispatcher");
         if let Some(promise) = self.notify_ready.take() {
-            promise.fulfil(()).unwrap_or(())
+            promise.complete().unwrap_or(())
         }
         Handled::Ok
     }

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -991,7 +991,7 @@ impl ComponentLifecycle for NetworkDispatcher {
         info!(self.ctx.log(), "Started network just fine.");
         if let Some(promise) = self.notify_ready.take() {
             promise
-                .fulfil(())
+                .complete()
                 .unwrap_or_else(|e| error!(self.ctx.log(), "Could not start network! {:?}", e))
         }
         Handled::Ok

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -285,6 +285,7 @@ pub mod prelude {
             on_dual_definition,
             promise,
             Ask,
+            Completable,
             Fulfillable,
             FutureCollection,
             FutureResultCollection,

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -374,7 +374,7 @@ fn run_network_thread(
             if let Err(e) = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 let network_thread = builder.build();
                 let _ = started_promise
-                    .fulfil(())
+                    .complete()
                     .expect("NetworkThread started but failed to fulfil promise");
                 network_thread.run()
             })) {

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -194,7 +194,7 @@ impl NetworkThread {
                 self.handle_event(event);
 
                 if self.stopped {
-                    if let Err(e) = self.shutdown_promise.fulfil(()) {
+                    if let Err(e) = self.shutdown_promise.complete() {
                         error!(self.log, "Error, shutting down sender: {:?}", e);
                     };
                     trace!(self.log, "Stopped");

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -273,7 +273,7 @@ pub trait Fulfillable<T> {
     fn fulfil(self, t: T) -> Result<(), PromiseErr>;
 }
 
-/// Anything that can be completeed without providing a value.
+/// Anything that can be completed without providing a value.
 pub trait Completable {
     /// Complete self
     ///

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -273,6 +273,14 @@ pub trait Fulfillable<T> {
     fn fulfil(self, t: T) -> Result<(), PromiseErr>;
 }
 
+/// Anything that can be completeed without providing a value.
+pub trait Completable {
+    /// Complete self
+    ///
+    /// Returns a [PromiseErr](PromiseErr) if unsuccessful.
+    fn complete(self) -> Result<(), PromiseErr>;
+}
+
 /// A custom promise implementation, that can be used to fulfil its paired future.
 #[derive(Debug)]
 pub struct KPromise<T: Send + Sized> {
@@ -284,6 +292,12 @@ impl<T: Send + Sized> Fulfillable<T> for KPromise<T> {
         self.result_channel
             .send(t)
             .map_err(|_| PromiseErr::ChannelBroken)
+    }
+}
+
+impl<T: Send + Sized + Default> Completable for KPromise<T> {
+    fn complete(self) -> Result<(), PromiseErr> {
+        self.fulfil(Default::default())
     }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Just a comment from #147 

## Breaking Changes

None

## Other Changes

- Added the new `Completable` trait to `KPromise`, allowing promises to be fulfilled using the default value of the underlying type by calling `promise.complete()`.
