### PR TITLE
Connection Limit added.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "kompact-actor-derive",
  "kompact-component-derive",
  "log",
+ "lru",
  "mio",
  "num_cpus",
  "once_cell",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,7 +60,7 @@ owning_ref 						= "0.4"
 futures 						= "0.3"
 async-std 						= "1.6"
 executors						= "0.8"
-lru                             = "0.6"
+lru								= "0.6"
 
 # Optional
 protobuf 						= {version = "2", optional = true, features = ["with-bytes"]}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,6 +60,7 @@ owning_ref 						= "0.4"
 futures 						= "0.3"
 async-std 						= "1.6"
 executors						= "0.8"
+lru                             = "0.6"
 
 # Optional
 protobuf 						= {version = "2", optional = true, features = ["with-bytes"]}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,7 +60,7 @@ owning_ref 						= "0.4"
 futures 						= "0.3"
 async-std 						= "1.6"
 executors						= "0.8"
-lru								= "0.6"
+lru 							= "0.6"
 
 # Optional
 protobuf 						= {version = "2", optional = true, features = ["with-bytes"]}

--- a/core/src/component/mod.rs
+++ b/core/src/component/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 
     use std::ops::Deref;
 
-    const TIMEOUT: Duration = Duration::from_millis(1000);
+    const TIMEOUT: Duration = Duration::from_millis(3000);
 
     #[derive(ComponentDefinition, Actor)]
     struct TestComponent {

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -47,10 +47,12 @@ pub mod lookup;
 pub mod queue_manager;
 
 // Default values for network config.
-const RETRY_CONNECTIONS_INTERVAL: u64 = 5000;
-const BOOT_TIMEOUT: u64 = 5000;
-const MAX_RETRY_ATTEMPTS: u8 = 10;
-const CONNECTION_LIMIT: u32 = 1000;
+mod defaults {
+    pub(crate) const RETRY_CONNECTIONS_INTERVAL: u64 = 5000;
+    pub(crate) const BOOT_TIMEOUT: u64 = 5000;
+    pub(crate) const MAX_RETRY_ATTEMPTS: u8 = 10;
+    pub(crate) const CONNECTION_LIMIT: u32 = 1000;
+}
 
 type NetHashMap<K, V> = FxHashMap<K, V>;
 
@@ -91,10 +93,10 @@ impl NetworkConfig {
             buffer_config: BufferConfig::default(),
             custom_allocator: None,
             tcp_nodelay: true,
-            max_connection_retry_attempts: MAX_RETRY_ATTEMPTS,
-            connection_retry_interval: RETRY_CONNECTIONS_INTERVAL,
-            boot_timeout: BOOT_TIMEOUT,
-            connection_limit: CONNECTION_LIMIT,
+            max_connection_retry_attempts: defaults::MAX_RETRY_ATTEMPTS,
+            connection_retry_interval: defaults::RETRY_CONNECTIONS_INTERVAL,
+            boot_timeout: defaults::BOOT_TIMEOUT,
+            connection_limit: defaults::CONNECTION_LIMIT,
         }
     }
 
@@ -121,10 +123,10 @@ impl NetworkConfig {
             buffer_config,
             custom_allocator: Some(custom_allocator),
             tcp_nodelay: true,
-            max_connection_retry_attempts: MAX_RETRY_ATTEMPTS,
-            connection_retry_interval: RETRY_CONNECTIONS_INTERVAL,
-            boot_timeout: BOOT_TIMEOUT,
-            connection_limit: CONNECTION_LIMIT,
+            max_connection_retry_attempts: defaults::MAX_RETRY_ATTEMPTS,
+            connection_retry_interval: defaults::RETRY_CONNECTIONS_INTERVAL,
+            boot_timeout: defaults::BOOT_TIMEOUT,
+            connection_limit: defaults::CONNECTION_LIMIT,
         }
     }
 
@@ -232,10 +234,10 @@ impl Default for NetworkConfig {
             buffer_config: BufferConfig::default(),
             custom_allocator: None,
             tcp_nodelay: true,
-            max_connection_retry_attempts: MAX_RETRY_ATTEMPTS,
-            connection_retry_interval: RETRY_CONNECTIONS_INTERVAL,
-            boot_timeout: BOOT_TIMEOUT,
-            connection_limit: CONNECTION_LIMIT,
+            max_connection_retry_attempts: defaults::MAX_RETRY_ATTEMPTS,
+            connection_retry_interval: defaults::RETRY_CONNECTIONS_INTERVAL,
+            boot_timeout: defaults::BOOT_TIMEOUT,
+            connection_limit: defaults::CONNECTION_LIMIT,
         }
     }
 }
@@ -271,7 +273,7 @@ pub enum NetworkStatus {
     UnblockedIp(IpAddr),
     /// The Connection Limit has been exceeded and the NetworkThread will close
     /// the least recently used connection(s).
-    ConnectionLimitExceeded(),
+    ConnectionLimitExceeded,
 }
 
 /// Sent by Actors and Components to request information about the Network
@@ -572,9 +574,9 @@ impl NetworkDispatcher {
                     self.network_status_port
                         .trigger(NetworkStatus::UnblockedIp(ip_addr));
                 }
-                NetworkEvent::ConnectionLimitExceeded() => self
+                NetworkEvent::ConnectionLimitExceeded => self
                     .network_status_port
-                    .trigger(NetworkStatus::ConnectionLimitExceeded()),
+                    .trigger(NetworkStatus::ConnectionLimitExceeded),
             },
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1044,7 +1044,7 @@ mod tests {
         let rcd_ref = rcd.actor_ref();
         rcd_ref.tell("MsgTest");
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(1000));
 
         rcd.on_definition(|c| {
             assert_eq!(c.last_string, String::from("MsgTest"));

--- a/core/src/messaging/mod.rs
+++ b/core/src/messaging/mod.rs
@@ -4,7 +4,6 @@ use crate::{
     actors::{ActorPath, DynActorRef, MessageBounds, PathParseError},
     net::{
         buffers::{BufferChunk, BufferEncoder, ChunkLease, ChunkRef},
-        events::NetworkEvent,
         frames::FRAME_HEAD_LEN,
     },
     serialisation::{
@@ -30,6 +29,7 @@ pub use serialised::*;
 pub(crate) mod dispatch;
 pub use dispatch::*;
 mod deser_macro;
+use crate::{net::SocketAddr, prelude::NetworkStatus};
 pub use deser_macro::*;
 
 pub mod framing;
@@ -40,7 +40,9 @@ pub mod framing;
 #[derive(Debug)]
 pub enum EventEnvelope {
     /// An event from the network
-    Network(NetworkEvent),
+    Network(NetworkStatus),
+    /// Rejected DispatchData, NetworkThread is unable to send it
+    RejectedData((SocketAddr, Box<DispatchData>)),
 }
 
 /// A message that is accepted by an actor's mailbox

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -112,7 +112,7 @@ pub mod events {
         UnblockedIp(IpAddr),
         /// The Channel Limit has been exceeded and the NetworkThread will close
         /// the least recently used channel(s).
-        ConnectionLimitExceeded(),
+        ConnectionLimitExceeded,
     }
 
     /// BridgeEvents emitted to the network `Bridge`
@@ -1417,7 +1417,7 @@ pub mod net_test_helpers {
                     self.blocked_systems.retain(|s| s != &sys_path)
                 }
                 NetworkStatus::UnblockedIp(ip_addr) => self.blocked_ip.retain(|ip| ip != &ip_addr),
-                NetworkStatus::ConnectionLimitExceeded() => self.connection_limit_exceeded += 1,
+                NetworkStatus::ConnectionLimitExceeded => self.connection_limit_exceeded += 1,
             }
             Handled::Ok
         }

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -110,6 +110,9 @@ pub mod events {
         UnblockedSocket(SocketAddr, bool),
         /// The NetworkThread has unblocked `IpAddr`
         UnblockedIp(IpAddr),
+        /// The Channel Limit has been exceeded and the NetworkThread will close
+        /// the least recently used channel(s).
+        ConnectionLimitExceeded(),
     }
 
     /// BridgeEvents emitted to the network `Bridge`
@@ -1305,7 +1308,7 @@ pub mod net_test_helpers {
         /// The blocked ip addresses
         pub blocked_ip: Vec<IpAddr>,
         /// Counts the number of max_channels_reached messages received
-        pub max_channels_reached: u32,
+        pub connection_limit_exceeded: u32,
         /// Counts the number of network_out_of_buffers messages received
         pub network_out_of_buffers: u32,
         network_status_queue_sender: Option<Sender<NetworkStatus>>,
@@ -1326,7 +1329,7 @@ pub mod net_test_helpers {
                 disconnected_systems: Vec::new(),
                 blocked_systems: Vec::new(),
                 blocked_ip: Vec::new(),
-                max_channels_reached: 0,
+                connection_limit_exceeded: 0,
                 network_out_of_buffers: 0,
                 network_status_queue_sender: None,
                 started_promise: None,
@@ -1414,6 +1417,7 @@ pub mod net_test_helpers {
                     self.blocked_systems.retain(|s| s != &sys_path)
                 }
                 NetworkStatus::UnblockedIp(ip_addr) => self.blocked_ip.retain(|ip| ip != &ip_addr),
+                NetworkStatus::ConnectionLimitExceeded() => self.connection_limit_exceeded += 1,
             }
             Handled::Ok
         }

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -2,7 +2,6 @@ use super::*;
 use actors::Transport;
 use arc_swap::ArcSwap;
 use dispatch::lookup::ActorStore;
-use net::events::NetworkEvent;
 
 use crate::{
     messaging::DispatchData,
@@ -84,37 +83,11 @@ impl SessionId {
 /// Events on the network level
 pub mod events {
 
-    use super::ConnectionState;
     use crate::{
         messaging::DispatchData,
-        net::{frames::*, SocketAddr},
+        net::SocketAddr,
     };
     use std::net::IpAddr;
-
-    /// Network events emitted by the network `Bridge`
-    #[derive(Debug)]
-    pub enum NetworkEvent {
-        /// The state of a connection changed
-        Connection(SocketAddr, ConnectionState),
-        /// Data was received
-        Data(Frame),
-        /// The NetworkThread lost connection to the remote host and rejects the frame
-        RejectedData(SocketAddr, DispatchData),
-        /// The NetworkThread has blocked `SocketAddr` and dropped its corresponding channel.
-        /// Boolean flag determines if an Indication on NetworkStatusPort should be triggered.
-        BlockedSocket(SocketAddr, bool),
-        /// The NetworkThread has blocked `IpAddr` and dropped all channels to it
-        BlockedIp(IpAddr),
-        /// The NetworkThread has unblocked `SocketAddr`
-        /// Boolean flag determines if an Indication on NetworkStatusPort should be triggered.
-        UnblockedSocket(SocketAddr, bool),
-        /// The NetworkThread has unblocked `IpAddr`
-        UnblockedIp(IpAddr),
-        /// The Channel Limit has been exceeded and the NetworkThread will close
-        /// the least recently used channel(s).
-        ConnectionLimitExceeded,
-    }
-
     /// BridgeEvents emitted to the network `Bridge`
     #[derive(Debug)]
     pub enum DispatchEvent {

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -83,10 +83,7 @@ impl SessionId {
 /// Events on the network level
 pub mod events {
 
-    use crate::{
-        messaging::DispatchData,
-        net::SocketAddr,
-    };
+    use crate::{messaging::DispatchData, net::SocketAddr};
     use std::net::IpAddr;
     /// BridgeEvents emitted to the network `Bridge`
     #[derive(Debug)]
@@ -1280,8 +1277,10 @@ pub mod net_test_helpers {
         pub blocked_systems: Vec<SystemPath>,
         /// The blocked ip addresses
         pub blocked_ip: Vec<IpAddr>,
-        /// Counts the number of max_channels_reached messages received
-        pub connection_limit_exceeded: u32,
+        /// Counts the number of `SoftConnectionLimitExceeded` messages received
+        pub soft_connection_limit_exceeded: u32,
+        /// Counts the number of `HardConnectionLimitReached` messages received
+        pub hard_connection_limit_reached: u32,
         /// Counts the number of network_out_of_buffers messages received
         pub network_out_of_buffers: u32,
         network_status_queue_sender: Option<Sender<NetworkStatus>>,
@@ -1302,7 +1301,8 @@ pub mod net_test_helpers {
                 disconnected_systems: Vec::new(),
                 blocked_systems: Vec::new(),
                 blocked_ip: Vec::new(),
-                connection_limit_exceeded: 0,
+                soft_connection_limit_exceeded: 0,
+                hard_connection_limit_reached: 0,
                 network_out_of_buffers: 0,
                 network_status_queue_sender: None,
                 started_promise: None,
@@ -1390,7 +1390,12 @@ pub mod net_test_helpers {
                     self.blocked_systems.retain(|s| s != &sys_path)
                 }
                 NetworkStatus::UnblockedIp(ip_addr) => self.blocked_ip.retain(|ip| ip != &ip_addr),
-                NetworkStatus::ConnectionLimitExceeded => self.connection_limit_exceeded += 1,
+                NetworkStatus::SoftConnectionLimitExceeded => {
+                    self.soft_connection_limit_exceeded += 1
+                }
+                NetworkStatus::HardConnectionLimitReached => {
+                    self.hard_connection_limit_reached += 1
+                }
             }
             Handled::Ok
         }

--- a/core/src/net/network_channel.rs
+++ b/core/src/net/network_channel.rs
@@ -302,15 +302,11 @@ impl TcpChannel {
     }
 
     /// If the channel is in connected the channel transitions to CloseRequested
-    /// and calls `clear_outbound_and_send_bye()`
-    /// If the method returns Ok() it must wait for a Bye message to be received.
-    pub fn initiate_graceful_shutdown(&mut self) -> io::Result<()> {
-        match self.state {
-            ChannelState::Connected(addr, id) => {
-                self.state = ChannelState::CloseRequested(addr, id);
-                self.send_bye()
-            }
-            _ => io::Result::Ok(()),
+    /// and sends a bye message
+    pub fn initiate_graceful_shutdown(&mut self) -> () {
+        if let ChannelState::Connected(addr, id) = self.state {
+            self.state = ChannelState::CloseRequested(addr, id);
+            let _ = self.send_bye();
         }
     }
 

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -825,7 +825,7 @@ impl NetworkThread {
                         self.log,
                         "Soft Connection Limit exceeded! limit = {}. Closing channel {:?}",
                         self.network_config.get_soft_connection_limit(),
-                        &addr,
+                        &channel.borrow(),
                     );
                     self.notify_network_status(NetworkStatus::SoftConnectionLimitExceeded);
                     self.close_connection(addr);
@@ -1512,19 +1512,13 @@ mod tests {
         input_queue_1_sender.send(DispatchEvent::Connect(addr5));
         thread1.receive_dispatch();
         // That it was immediately discarded
-        assert!(thread1
-            .address_map
-            .get(&addr5)
-            .is_none());
+        assert!(thread1.address_map.get(&addr5).is_none());
 
         // This should do nothing...
         run_handshake_sequence(&mut thread1, &mut thread5);
 
         // Assert channels are unchanged
-        assert!(thread1
-            .address_map
-            .get(&addr5)
-            .is_none());
+        assert!(thread1.address_map.get(&addr5).is_none());
         assert!(thread1
             .address_map
             .get(&addr2)
@@ -1550,19 +1544,13 @@ mod tests {
         thread::sleep(Duration::from_millis(100));
         poll_and_handle(&mut thread1);
         // Should have been rejected immediately
-        assert!(thread1
-            .address_map
-            .get(&addr5)
-            .is_none());
+        assert!(thread1.address_map.get(&addr5).is_none());
 
         // This should do nothing
         run_handshake_sequence(&mut thread5, &mut thread1);
 
         // Assert channels are unchanged
-        assert!(thread1
-            .address_map
-            .get(&addr5)
-            .is_none());
+        assert!(thread1.address_map.get(&addr5).is_none());
         assert!(thread1
             .address_map
             .get(&addr2)

--- a/core/src/routing/groups.rs
+++ b/core/src/routing/groups.rs
@@ -308,7 +308,8 @@ mod tests {
 
     const GROUP_SIZE: usize = 3;
     const NUM_MESSAGES: usize = 30;
-    const SLEEP_TIME: Duration = Duration::from_millis(100);
+    // TODO: Replace the sleeps
+    const SLEEP_TIME: Duration = Duration::from_millis(1000);
 
     #[test]
     fn router_debug() {

--- a/core/src/routing/mod.rs
+++ b/core/src/routing/mod.rs
@@ -98,7 +98,7 @@ mod tests {
 
     const GROUP_SIZE: usize = 3;
     const NUM_MESSAGES: usize = 30;
-    const SLEEP_TIME: Duration = Duration::from_millis(1000);
+    const SLEEP_TIME: Duration = Duration::from_millis(3000);
 
     #[test]
     fn test_explicit_round_robin_select() {

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1817,5 +1817,17 @@ fn hard_and_soft_connection_limit() {
         pinger_futures.push(future);
     }
 
-    pinger_futures.expect_completion(timeout, "One or more systems failed to reconnect properly");
+    pinger_futures.expect_completion(timeout, {
+        for pinger in pingers {
+            pinger.on_definition(|p| {
+                if p.count < 10 {
+                    info!(
+                        pinger.logger(),
+                        "Connection Limit test failed, pong count: {}", p.count
+                    );
+                }
+            });
+        }
+        "One or more pingers failed"
+    });
 }

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1781,10 +1781,10 @@ fn hard_connection_limit_exceeded() {
 
 #[allow(dead_code)]
 #[cfg_attr(not(feature = "low_latency"), test)]
-// Sets up one KompactSystem with one Ponger, specific NetworkConfig,
-// Then creates many different KompactSystems with Pingers each pinging the ponger
-// Eventually all Pings and Pongs should be received as the Connections are always gracefully closed
-// and messages are retained while they wait for connections to be re-established
+// Sets up one KompactSystem with one Ponger, with a hard_limit of 6 and soft_limit of 4.
+// Then creates 30 KompactSystems with Pingers, each pinging the ponger.
+// Eventually all Pings and Pongs should be received. The Connections are always gracefully closed,
+// and thus messages are retained while the pinger-systems take turns achieving active connections.
 fn hard_and_soft_connection_limit() {
     let mut net_cfg = NetworkConfig::default();
     let hard_limit = 6;

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1779,7 +1779,8 @@ fn hard_connection_limit_exceeded() {
         .expect("Kompact didn't shut down properly");
 }
 
-#[test]
+#[allow(dead_code)]
+#[cfg_attr(not(feature = "low_latency"), test)]
 // Sets up one KompactSystem with one Ponger, specific NetworkConfig,
 // Then creates many different KompactSystems with Pingers each pinging the ponger
 // Eventually all Pings and Pongs should be received as the Connections are always gracefully closed

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -220,7 +220,7 @@ impl NetworkStatusReceiver {
 
     fn expect_connection_limit_exceeded(&self, timeout: Duration) {
         match self.receiver.recv_timeout(timeout) {
-            Ok(NetworkStatus::ConnectionLimitExceeded()) => {}
+            Ok(NetworkStatus::ConnectionLimitExceeded) => {}
             Ok(other_status) => {
                 panic!(
                     "unexpected network status {:?} waiting for UnblockedIp",


### PR DESCRIPTION
Add Status message for Connection Limit Exceeded.

Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Closes #83 

## Breaking Changes

Added two configurable Connection Limits, `Hard Connection Limit` and `Soft Connection Limit` which limits the amount concurrent active connections a system may have. 
`Soft Connection Limit`limits the number of concurrent Active Connections a system may have, while the hard limit limits the total number of connections (i.e. in process of closing or handshake for new connections).
When the Soft Limit is exceeded by a new connection entering the connected state, the least recently used active connection will be closed gracefully. 
When the Hard Limit is reached by new incoming or outgoing requests, the requests will be denied immediately.
The new integration test "soft_and_hard_limit" tests (and showcases) the interplay of these two limits:
```
// Sets up one KompactSystem with one Ponger, with a hard_limit of 6 and soft_limit of 4.
// Then creates 30 KompactSystems with Pingers, each pinging the ponger.
// Eventually all Pings and Pongs should be received. The Connections are always gracefully closed,
// and thus messages are retained while the pinger-systems take turns achieving active connections.
fn hard_and_soft_connection_limit() {
...
```

## Other Changes

`NetworkStatus::SoftConnectionLimitExceeded` and `NetworkStatus::HardConnectionLimitReached` message added to the NetworkStatusPort. 

Refactored the NetworkEvent struct to avoid duplicate code. Extended some sleeps in various tests to avoid flakyness of the integration tests. 