### PR TITLE
Make KompactSystem recover from Panics in the NetworkThread

### DIFF
--- a/core/src/net/network_channel.rs
+++ b/core/src/net/network_channel.rs
@@ -322,7 +322,9 @@ impl TcpChannel {
     pub fn decode(&mut self) -> Result<Frame, FramingError> {
         match self.input_buffer.get_frame() {
             Ok(frame) => {
-                self.messages += 1;
+                if matches!(frame, Frame::Data(_)) {
+                    self.messages += 1;
+                }
                 Ok(frame)
             }
             Err(e) => Err(e),

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -1016,7 +1016,7 @@ impl std::ops::Drop for NetworkThread {
         if !self.stopped {
             while let Some((_, channel)) = self.token_map.pop_lru() {
                 trace!(self.log, "Dropping channel in crashed NetworkThread");
-                self.drop_channel(&mut *channel.borrow_mut());
+                self.drop_channel(&mut channel.borrow_mut());
             }
         }
     }

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -616,6 +616,10 @@ impl NetworkThread {
                     self.drop_channel(channel);
                     return;
                 }
+                ChannelState::Connected(_, _) => {
+                    // treat this as a channel loss
+                    self.lost_connection(other_channel);
+                }
                 _ => {
                     self.drop_channel(other_channel.deref_mut());
                 }

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -603,7 +603,10 @@ impl NetworkThread {
         }
         if let Some(other_channel_rc) = self.get_channel_by_address(&start.addr) {
             let mut other_channel = other_channel_rc.borrow_mut();
-            debug!(self.log, "Merging channels {:?} and {:?}", channel, other_channel);
+            debug!(
+                self.log,
+                "Merging channels {:?} and {:?}", channel, other_channel
+            );
             match other_channel.read_state() {
                 ChannelState::Requested(_, other_id) if other_id.0 > start.id.0 => {
                     self.drop_channel(channel);

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -143,7 +143,7 @@ impl NetworkThreadBuilder {
             input_queue: self.input_queue,
             buffer_pool: RefCell::new(buffer_pool),
             stopped: false,
-            shutdown_promise: self.shutdown_promise,
+            shutdown_promise: Some(self.shutdown_promise),
             dispatcher_ref: self.dispatcher_ref,
             network_config: self.network_config,
             retry_queue: VecDeque::new(),
@@ -168,7 +168,7 @@ pub struct NetworkThread {
     dispatcher_ref: DispatcherRef,
     buffer_pool: RefCell<BufferPool>,
     stopped: bool,
-    shutdown_promise: KPromise<()>,
+    shutdown_promise: Option<KPromise<()>>,
     network_config: NetworkConfig,
     retry_queue: VecDeque<EventWithRetries>,
     out_of_buffers: bool,
@@ -193,7 +193,11 @@ impl NetworkThread {
                 self.handle_event(event);
 
                 if self.stopped {
-                    if let Err(e) = self.shutdown_promise.complete() {
+                    if let Some(Err(e)) = self
+                        .shutdown_promise
+                        .take()
+                        .map(|promise| promise.complete())
+                    {
                         error!(self.log, "Error, shutting down sender: {:?}", e);
                     };
                     trace!(self.log, "Stopped");
@@ -604,10 +608,6 @@ impl NetworkThread {
             );
             let mut other_channel = other_channel_rc.borrow_mut();
             match other_channel.read_state() {
-                ChannelState::Connected(_, _) => {
-                    self.drop_channel(channel);
-                    return;
-                }
                 ChannelState::Requested(_, other_id) if other_id.0 > start.id.0 => {
                     self.drop_channel(channel);
                     return;
@@ -898,6 +898,7 @@ impl NetworkThread {
                 "Stopping channel with message count {}", channel.messages
             );
             let _ = channel.initiate_graceful_shutdown();
+            let _ = self.token_map.pop(&channel.token);
         }
         self.poll
             .registry()
@@ -1004,6 +1005,18 @@ impl NetworkThread {
                 self.notify_network_status(NetworkStatus::UnblockedSystem(
                     SystemPath::with_socket(Transport::Tcp, socket_addr),
                 ));
+            }
+        }
+    }
+}
+
+impl std::ops::Drop for NetworkThread {
+    fn drop(&mut self) {
+        // Ensure that the channels are shutdown and buffers are deallocated on panic
+        if !self.stopped {
+            while let Some((_, channel)) = self.token_map.pop_lru() {
+                trace!(self.log, "Dropping channel in crashed NetworkThread");
+                self.drop_channel(&mut *channel.borrow_mut());
             }
         }
     }

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1914,10 +1914,10 @@ fn network_thread_recovery_from_panic_in_receiver() {
     ponger_status_receiver.expect_critical_network_failure(CONNECTION_STATUS_TIMEOUT);
     ponger_status_receiver.expect_connection_lost(CONNECTION_STATUS_TIMEOUT);
 
+    pinger_status_receiver.expect_connection_lost(CONNECTION_STATUS_TIMEOUT * 5);
     // Create two new pingers and we expect the first one to fail, a new connection to be established
     let (_failing_pinger, _) =
         start_pinger(&pinger_system, PingerAct::new_lazy(ponger_path.clone()));
-    pinger_status_receiver.expect_connection_lost(CONNECTION_STATUS_TIMEOUT * 5);
     let (_new_pinger, new_pinger_future) =
         start_pinger(&pinger_system, PingerAct::new_lazy(ponger_path));
 

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -1891,8 +1891,8 @@ fn network_thread_recovery_from_panic_in_sender() {
 #[cfg_attr(not(feature = "low_latency"), test)]
 // Same as above except the Panic is induced in the Ponger-system
 fn network_thread_recovery_from_panic_in_receiver() {
-    let net_cfg = NetworkConfig::default();
-
+    let mut net_cfg = NetworkConfig::default();
+    net_cfg.set_connection_retry_interval(CONNECTION_STATUS_TIMEOUT.as_millis() as u64);
     let pinger_system = system_from_network_config(net_cfg.clone());
     let ponger_system = system_from_network_config(net_cfg);
 


### PR DESCRIPTION
Made NetworkDispatcher catch panics in the NetworkThread and launch a new NetworkThread.

Added two simple integration tests which induces a panic in the NetworkThread and asserts that it successfully re-establishes the connection. The tests set up a pinger and a ponger system and differs by which system they induce a panic in.

Please make sure these boxes are checked, before submitting a new PR.

- [X] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [X] You reference which issue is being closed in the PR text (if applicable)

## Issues

Closes #144 

## Breaking Changes

**Change in expected behaviour:**   
A panic in the NetworkThread may be caused by an incorrect serialiser, which would previously just cause the system to crash entirely. If the `NetworkThread` panics the entire local system will not panic, but instead it will re-launch the `NetworkThread`.  
**Message loss scenarios:**   
Outgoing messages sent after a local NetworkThread panic, but before the recovery has been triggered, will be dropped by the `NetworkDispatcher` as it fails to forward them to the `NetworkThread`.   
Messages sent to a remote panicking system may be lost if they are sent before the channel has been detected as faulty by the local non-panicking-system.