### PR TITLE
Adjust macro test output to fit latest nightly

### DIFF
--- a/core/tests/compile-fail/match_deser_tests.stderr
+++ b/core/tests/compile-fail/match_deser_tests.stderr
@@ -6,7 +6,7 @@ error: Must specify a deserialisation target type
 6 | |             msg(_res) [using String] => (), //~ ERROR: Must specify a deserialisation target type
 7 | |         }
 8 | |     };
-  | |______^
+  | |_____^
   |
   = note: this error originates in the macro `$crate::match_deser_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error: Illegal case `nsg`. Allowed values: [`msg`, `err`, `default`]
 11 | |             nsg(_res): String => (), //~ ERROR: Illegal case `nsg`. Allowed values: [`msg`, `err`, `default`]
 12 | |         }
 13 | |     };
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `$crate::match_deser_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -30,7 +30,7 @@ error: Illegal `match_deser!` item(s). See docs for example of legal items. Offe
 16 | |             my_msg: String => (), //~ ERROR: Illegal `match_deser!` item(s). See docs for example of legal items.  Offending item(s): my_...
 17 | |         }
 18 | |     };
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `$crate::match_deser_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error: Illegal `match_deser!` item(s). See docs for example of legal items. Offe
 21 | |             my_msg: String => () //~ ERROR: Illegal `match_deser!` items(s). See docs for example of legal items.  Offending item(s): my_...
 22 | |         }
 23 | |     };
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `$crate::match_deser_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Macro tests were failing on master with latest nightly due to tiny formatting change.

## Other Changes

Regenerated the output files to the macro tests.
