### PR TITLE
Fixing a flaky test

### DIFF
--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -911,9 +911,11 @@ fn remote_lost_and_continued_connection() {
             (c.connected_systems[0].1, c.connected_systems[1].1)
         })
     };
-    ping_stream.on_definition(|c| {
-        assert_eq!(first_session, c.pong_system_paths[0].1);
-        assert_eq!(second_session, c.pong_system_paths[1].1);
+    pinger_1.on_definition(|c| {
+        assert_eq!(first_session, c.pong_system_session.unwrap());
+    });
+    pinger_2.on_definition(|c| {
+        assert_eq!(second_session, c.pong_system_session.unwrap());
     });
 
     pinger_system


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Other Changes

Just tiny changes in the net_test_helpers actors and the dispatch_integration_tests.
