### PR TITLE
Macro test output and bump CI-nightly version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-10-08
+          toolchain: nightly-2022-04-11
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock
@@ -199,7 +199,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-10-27
+          toolchain: nightly-2022-04-11
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-12-04
+          toolchain: nightly-2021-10-08
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           command: build
         env:
-          RUSTFLAGS: '-Zinstrument-coverage'
-          RUSTDOCFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
+          RUSTDOCFLAGS: '-Cinstrument-coverage'
       - name: Run tests
         env:
-          RUSTFLAGS: '-Zinstrument-coverage'
-          RUSTDOCFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
+          RUSTDOCFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'codecov-instrumentation-%p-%m.profraw'
         run: |
           cargo test --features slog/max_level_error

--- a/core/src/component/future_task.rs
+++ b/core/src/component/future_task.rs
@@ -204,10 +204,10 @@ mod task_waker {
             Self::drop_waker,
         );
 
-        #[allow(clippy::redundant_clone)]
+        #[allow(clippy::undropped_manually_drops)]
         unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
             let arc = ManuallyDrop::new(Arc::from_raw(ptr as *const TaskWaker));
-            mem::forget(arc.clone());
+            mem::drop(arc.clone());
             RawWaker::new(ptr, &Self::VTABLE)
         }
 

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -593,6 +593,7 @@ impl NetworkDispatcher {
                     self.connection_closed(system_path, session)
                 }
                 NetworkStatus::ConnectionDropped(system_path) => {
+                    let _ = self.retry_map.remove(&system_path.socket_address());
                     self.network_status_port
                         .trigger(NetworkStatus::ConnectionDropped(system_path));
                 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -684,7 +684,7 @@ mod tests {
     fn test_dedicated_pinning() -> () {
         let core_ids = core_affinity::get_core_ids().expect("Failed to fetch core ids");
         assert!(
-            (core_ids.len() >= 2),
+            core_ids.len() >= 2,
             "this test requires at least two cores"
         );
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -684,7 +684,7 @@ mod tests {
     fn test_dedicated_pinning() -> () {
         let core_ids = core_affinity::get_core_ids().expect("Failed to fetch core ids");
         assert!(
-            !(core_ids.len() < 2),
+            (core_ids.len() >= 2),
             "this test requires at least two cores"
         );
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -683,10 +683,7 @@ mod tests {
     #[cfg(feature = "thread_pinning")]
     fn test_dedicated_pinning() -> () {
         let core_ids = core_affinity::get_core_ids().expect("Failed to fetch core ids");
-        assert!(
-            core_ids.len() >= 2,
-            "this test requires at least two cores"
-        );
+        assert!(core_ids.len() >= 2, "this test requires at least two cores");
 
         let system = KompactConfig::default().build().expect("System");
         let cc = system.create_dedicated_pinned(CounterComponent::new, core_ids[0]);

--- a/core/src/net/buffers/decode_buffer.rs
+++ b/core/src/net/buffers/decode_buffer.rs
@@ -73,7 +73,7 @@ impl DecodeBuffer {
     }
 
     /// True if there is sufficient amount of writeable bytes
-    pub(crate) fn is_writeable(&mut self) -> bool {
+    pub(crate) fn is_writeable(&self) -> bool {
         self.writeable_len() > 8
     }
 

--- a/core/src/net/network_thread.rs
+++ b/core/src/net/network_thread.rs
@@ -981,10 +981,12 @@ impl NetworkThread {
                         "Dropping channel to blocked socket: {:?}", socket_addr
                     );
                     let mut channel = channel_rc.borrow_mut();
+                    if channel.connected() {
+                        self.notify_network_status(NetworkStatus::ConnectionDropped(
+                            SystemPath::with_socket(Transport::Tcp, socket_addr),
+                        ));
+                    }
                     self.drop_channel(&mut channel);
-                    self.notify_network_status(NetworkStatus::ConnectionDropped(
-                        SystemPath::with_socket(Transport::Tcp, socket_addr),
-                    ));
                 }
             }
         }
@@ -1045,10 +1047,12 @@ impl NetworkThread {
                     "Dropping channel to blocked socket: {:?}", socket_addr
                 );
                 let mut channel = channel_rc.borrow_mut();
+                if channel.connected() {
+                    self.notify_network_status(NetworkStatus::ConnectionDropped(
+                        SystemPath::with_socket(Transport::Tcp, socket_addr),
+                    ));
+                }
                 self.drop_channel(&mut channel);
-                self.notify_network_status(NetworkStatus::ConnectionDropped(
-                    SystemPath::with_socket(Transport::Tcp, socket_addr),
-                ));
             }
         }
         self.notify_network_status(NetworkStatus::BlockedIpNet(ip_net));

--- a/core/src/runtime/scheduler.rs
+++ b/core/src/runtime/scheduler.rs
@@ -105,7 +105,7 @@ fn maybe_reschedule(c: Arc<dyn CoreContainer>) {
         SchedulingDecision::Schedule => {
             if cfg!(feature = "use_local_executor") {
                 let res = try_execute_locally(move || maybe_reschedule(c));
-                assert!(!res.is_err(), "Only run with Executors that can support local execute or remove the avoid_executor_lookups feature!");
+                assert!(res.is_ok(), "Only run with Executors that can support local execute or remove the avoid_executor_lookups feature!");
             } else {
                 let c2 = c.clone();
                 c.system().schedule(c2);

--- a/core/src/timer/timer_manager.rs
+++ b/core/src/timer/timer_manager.rs
@@ -327,7 +327,6 @@ pub(crate) enum TimerHandle<C: ComponentDefinition> {
 // This isn't technically true, but I know I'm never actually sending
 // individual Rc instances to different threads. Only the whole component
 // with all its Rc instances crosses threads sometimes.
-#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<C: ComponentDefinition> Send for TimerHandle<C> {}
 
 #[derive(Clone)]

--- a/core/src/timer/timer_manager.rs
+++ b/core/src/timer/timer_manager.rs
@@ -327,6 +327,7 @@ pub(crate) enum TimerHandle<C: ComponentDefinition> {
 // This isn't technically true, but I know I'm never actually sending
 // individual Rc instances to different threads. Only the whole component
 // with all its Rc instances crosses threads sometimes.
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<C: ComponentDefinition> Send for TimerHandle<C> {}
 
 #[derive(Clone)]

--- a/core/tests/compile-fail/component_derive_tests.stderr
+++ b/core/tests/compile-fail/component_derive_tests.stderr
@@ -1,5 +1,5 @@
 error: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "provided_test_port2"]). You cannot derive ComponentDefinition in these cases, as you must resolve the ambiguity manually.
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ error: Ambiguous port type: There are multiple fields with type TestPort (["prov
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Ambiguous port type: There are multiple fields with type TestPort (["required_test_port1", "required_test_port2"]). You cannot derive ComponentDefinition in these cases, as you must resolve the ambiguity manually.
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error: Ambiguous port type: There are multiple fields with type TestPort (["requ
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0407]: method `provided_ref` is not a member of trait `RequireRef`
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^ not a member of trait `RequireRef`
@@ -23,7 +23,7 @@ error[E0407]: method `provided_ref` is not a member of trait `RequireRef`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0407]: method `connect_to_required` is not a member of trait `RequireRef`
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ error[E0407]: method `connect_to_required` is not a member of trait `RequireRef`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not satisfied
-  --> $DIR/component_derive_tests.rs:12:10
+  --> tests/compile-fail/component_derive_tests.rs:12:10
    |
 12 |     ctx: ComponentContext<Self>,
    |          ^^^^^^^^^^^^^^^^^^^^^^ the trait `NetworkActor` is not implemented for `DuplicatePortComponent`
@@ -43,41 +43,55 @@ error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not sati
    = note: required because of the requirements on the impl of `ActorRaw` for `DuplicatePortComponent`
    = note: required because of the requirements on the impl of `ComponentTraits` for `DuplicatePortComponent`
 note: required by a bound in `kompact::component::ComponentContext`
-  --> $DIR/context.rs:28:33
+  --> src/component/context.rs
    |
-28 | pub struct ComponentContext<CD: ComponentTraits> {
+   | pub struct ComponentContext<CD: ComponentTraits> {
    |                                 ^^^^^^^^^^^^^^^ required by this bound in `kompact::component::ComponentContext`
 
 error[E0277]: the trait bound `DuplicatePortComponent: ComponentLifecycle` is not satisfied
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^ the trait `ComponentLifecycle` is not implemented for `DuplicatePortComponent`
    |
+   = help: the following other types implement trait `ComponentLifecycle`:
+             BigPingerAct
+             BigPongerAct
+             DeadletterBox
+             ForwarderAct
+             LocalDispatcher
+             NetworkDispatcher
+             NetworkStatusCounter
+             PingStream
+           and 5 others
 note: required by a bound in `kompact::component::ComponentDefinition`
-  --> $DIR/definition.rs:30:32
+  --> src/component/definition.rs
    |
-30 | pub trait ComponentDefinition: DynamicComponentDefinition
+   | pub trait ComponentDefinition: DynamicComponentDefinition
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `kompact::component::ComponentDefinition`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not satisfied
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^ the trait `NetworkActor` is not implemented for `DuplicatePortComponent`
    |
+   = help: the following other types implement trait `ActorRaw`:
+             TestComponent1
+             TestComponent2
+             kompact::supervision::ComponentSupervisor
    = note: required because of the requirements on the impl of `kompact::prelude::Actor` for `DuplicatePortComponent`
    = note: required because of the requirements on the impl of `ActorRaw` for `DuplicatePortComponent`
 note: required by a bound in `kompact::component::ComponentDefinition`
-  --> $DIR/definition.rs:30:32
+  --> src/component/definition.rs
    |
-30 | pub trait ComponentDefinition: DynamicComponentDefinition
+   | pub trait ComponentDefinition: DynamicComponentDefinition
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `kompact::component::ComponentDefinition`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not satisfied
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^ the trait `NetworkActor` is not implemented for `DuplicatePortComponent`
@@ -86,14 +100,14 @@ error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not sati
    = note: required because of the requirements on the impl of `ActorRaw` for `DuplicatePortComponent`
    = note: required because of the requirements on the impl of `ComponentTraits` for `DuplicatePortComponent`
 note: required by a bound in `kompact::component::Component`
-  --> $DIR/actual_component.rs:50:26
+  --> src/component/actual_component.rs
    |
-50 | pub struct Component<CD: ComponentTraits> {
+   | pub struct Component<CD: ComponentTraits> {
    |                          ^^^^^^^^^^^^^^^ required by this bound in `kompact::component::Component`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not satisfied
-  --> $DIR/component_derive_tests.rs:10:10
+  --> tests/compile-fail/component_derive_tests.rs:10:10
    |
 10 | #[derive(ComponentDefinition)] //~ ERROR: Ambiguous port type: There are multiple fields with type TestPort (["provided_test_port1", "pro...
    |          ^^^^^^^^^^^^^^^^^^^ the trait `NetworkActor` is not implemented for `DuplicatePortComponent`
@@ -102,8 +116,8 @@ error[E0277]: the trait bound `DuplicatePortComponent: NetworkActor` is not sati
    = note: required because of the requirements on the impl of `ActorRaw` for `DuplicatePortComponent`
    = note: required because of the requirements on the impl of `ComponentTraits` for `DuplicatePortComponent`
 note: required by a bound in `kompact::component::ComponentContext`
-  --> $DIR/context.rs:28:33
+  --> src/component/context.rs
    |
-28 | pub struct ComponentContext<CD: ComponentTraits> {
+   | pub struct ComponentContext<CD: ComponentTraits> {
    |                                 ^^^^^^^^^^^^^^^ required by this bound in `kompact::component::ComponentContext`
    = note: this error originates in the derive macro `ComponentDefinition` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/tests/dispatch_integration_tests.rs
+++ b/core/tests/dispatch_integration_tests.rs
@@ -224,12 +224,12 @@ impl NetworkStatusReceiver {
             Ok(NetworkStatus::BlockedIpNet(_)) => {}
             Ok(other_status) => {
                 panic!(
-                    "unexpected network status {:?} waiting for BlockedIp",
+                    "unexpected network status {:?} waiting for BlockedIpNet",
                     other_status
                 )
             }
             Err(_) => {
-                panic!("ConnectionStatus timeout waiting for BlockedIp")
+                panic!("ConnectionStatus timeout waiting for BlockedIpNet")
             }
         }
     }


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Other Changes
Fixed the Macros Test Output to match the new output. 
Bumped the CI-nightly version and attended to the latest warnings.