### PR TITLE
Update Github cache actions from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -63,7 +63,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -101,7 +101,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -137,7 +137,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -188,7 +188,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [ ] ~~You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)~~
- [ ] ~~You reference which issue is being closed in the PR text (if applicable)~~

## Issues

- Github is phasing out v2 cache action, so this PR updates it to the latest v4.
