### PR TITLE
[codex] Capture Kompact test logging through libtest

### DIFF
--- a/core/src/component/mod.rs
+++ b/core/src/component/mod.rs
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn component_core_send() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -880,7 +880,10 @@ mod tests {
     #[cfg(feature = "distributed")]
     #[test]
     fn child_unique_registration_test() -> () {
-        let system = KompactConfig::default().build().wait().expect("system");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("system");
         let parent = system.create(ParentComponent::unique);
         system.start(&parent);
         thread::sleep(TIMEOUT);
@@ -903,7 +906,10 @@ mod tests {
     #[cfg(feature = "distributed")]
     #[test]
     fn child_alias_registration_test() -> () {
-        let system = KompactConfig::default().build().wait().expect("system");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("system");
         let parent = system.create(|| ParentComponent::alias(TEST_ALIAS.into()));
         system.start(&parent);
         thread::sleep(TIMEOUT);
@@ -953,7 +959,10 @@ mod tests {
         ignore_requests!(B, TestComp);
         ignore_indications!(A, TestComp);
 
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(TestComp::new);
         let dynamic: Arc<dyn AbstractComponent<Message = Never>> = comp;
         dynamic.on_dyn_definition(|def| {
@@ -1056,7 +1065,10 @@ mod tests {
 
     #[test]
     fn test_immediate_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(BlockingComponent::new);
         system
             .start_notify(&comp)
@@ -1076,7 +1088,10 @@ mod tests {
 
     #[test]
     fn test_channel_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(BlockingComponent::new);
         system
             .start_notify(&comp)
@@ -1100,7 +1115,10 @@ mod tests {
 
     #[test]
     fn test_mixed_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(BlockingComponent::new);
         system
             .start_notify(&comp)
@@ -1125,7 +1143,10 @@ mod tests {
 
     #[test]
     fn test_shutdown_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(BlockingComponent::new);
         system
             .start_notify(&comp)
@@ -1145,7 +1166,10 @@ mod tests {
 
     #[test]
     fn test_component_spawn_off() -> () {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(BlockingComponent::new);
         system
             .start_notify(&comp)
@@ -1256,7 +1280,10 @@ mod tests {
 
     #[test]
     fn test_immediate_non_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(AsyncComponent::new);
         system
             .start_notify(&comp)
@@ -1276,7 +1303,10 @@ mod tests {
 
     #[test]
     fn test_channel_non_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(AsyncComponent::new);
         system
             .start_notify(&comp)
@@ -1300,7 +1330,10 @@ mod tests {
 
     #[test]
     fn test_concurrent_non_blocking() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let comp = system.create(AsyncComponent::new);
         system
             .start_notify(&comp)
@@ -1413,7 +1446,10 @@ mod tests {
 
     #[test]
     fn test_channel_disconnection() {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let sender = system.create(CountSender::default);
 
         let counter1 = system.create(Counter::default);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -122,6 +122,8 @@ pub mod routing;
 pub mod runtime;
 mod serialisation;
 mod supervision;
+/// Test support utilities
+pub mod test_support;
 /// Reusable timer facility internals
 pub mod timer;
 mod utils;
@@ -319,7 +321,7 @@ pub mod prelude {
 ///
 /// Import all with `use prelude_test::*;`.
 pub mod prelude_test {
-    pub use crate::serialisation::ser_test_helpers;
+    pub use crate::{serialisation::ser_test_helpers, test_support};
 }
 
 /// A module containing helper functions for benchmarking
@@ -548,7 +550,7 @@ mod tests {
 
     #[test]
     fn default_settings() {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -558,7 +560,7 @@ mod tests {
 
     #[test]
     fn custom_settings() {
-        let mut settings = KompactConfig::default();
+        let mut settings = crate::test_support::test_kompact_config();
         settings.set_config_value(
             &crate::config_keys::system::LABEL,
             "custom-system".to_string(),
@@ -573,7 +575,7 @@ mod tests {
 
     #[test]
     fn custom_executor() {
-        let mut settings = KompactConfig::default();
+        let mut settings = crate::test_support::test_kompact_config();
         settings
             .set_config_value(&crate::config_keys::system::THREADS, 2)
             .executor(executors::crossbeam_channel_pool::ThreadPool::new);
@@ -583,7 +585,7 @@ mod tests {
 
     #[test]
     fn custom_scheduler() {
-        let mut settings = KompactConfig::default();
+        let mut settings = crate::test_support::test_kompact_config();
         settings.scheduler(move |t| {
             crate::runtime::ExecutorScheduler::from(
                 executors::crossbeam_channel_pool::ThreadPool::new(t),
@@ -673,7 +675,10 @@ mod tests {
 
     #[test]
     fn test_dedicated_ref() -> () {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let cc = system.create_dedicated(CounterComponent::new);
         system.start(&cc);
         let cc_ref: ActorRef<Box<dyn Any + Send>> = cc.actor_ref();
@@ -704,7 +709,10 @@ mod tests {
         let core_ids = core_affinity::get_core_ids().expect("Failed to fetch core ids");
         assert!(core_ids.len() >= 2, "this test requires at least two cores");
 
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
         let cc = system.create_dedicated_pinned(CounterComponent::new, core_ids[0]);
         system.start(&cc);
         let cc_ref: ActorRef<Box<dyn Any + Send>> = cc.actor_ref();
@@ -732,7 +740,10 @@ mod tests {
 
     #[test]
     fn test_dedicated() -> () {
-        let system = KompactConfig::default().build().wait().expect("System");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("System");
 
         let tc = system.create_dedicated(TestComponent::new);
         let rc = system.create_dedicated(RecvComponent::new);
@@ -807,7 +818,7 @@ mod tests {
 
     #[test]
     fn test_timer() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -862,7 +873,7 @@ mod tests {
 
     #[test]
     fn test_start_stop() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -982,7 +993,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_component_failure() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -1043,7 +1054,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_component_recovery() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -1198,7 +1209,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_component_recovery_with_state() -> () {
-        let system = KompactConfig::default()
+        let system = crate::test_support::test_kompact_config()
             .build()
             .wait()
             .expect("KompactSystem");
@@ -1274,7 +1285,10 @@ mod tests {
 
     #[test]
     fn test_async_shutdown() -> () {
-        let system = KompactConfig::default().build().wait().expect("system");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("system");
         let stopper = system.create(Stopper::new);
         system.start(&stopper);
         system.await_termination();
@@ -1283,7 +1297,10 @@ mod tests {
     #[test]
     fn test_async_terminated_inside_futures_executor() -> () {
         futures::executor::block_on(async {
-            let system = KompactConfig::default().build().await.expect("system");
+            let system = crate::test_support::test_kompact_config()
+                .build()
+                .await
+                .expect("system");
             let stopper = system.create(Stopper::new);
             system.start(&stopper);
             system.terminated().await;
@@ -1316,7 +1333,7 @@ mod tests {
     #[test]
     fn test_config_from_string() -> () {
         let default_values = r#"a = 7"#;
-        let mut conf = KompactConfig::default();
+        let mut conf = crate::test_support::test_kompact_config();
         conf.load_config_str(default_values);
         let system = conf.build().wait().expect("system");
         let c = system.create(ConfigComponent::new);
@@ -1333,7 +1350,7 @@ mod tests {
         let config_file_path = Fixture::blank("test_settings.toml");
         let mut config_file = File::create(config_file_path.deref()).expect("config file");
         config_file.write_all(b"a = 7").expect("write config file");
-        let mut conf = KompactConfig::default();
+        let mut conf = crate::test_support::test_kompact_config();
         conf.load_config_file(config_file_path.to_path_buf());
         let system = conf.build().wait().expect("system");
         let c = system.create(ConfigComponent::new);
@@ -1350,7 +1367,7 @@ mod tests {
         let config_file_path = Fixture::blank("test_settings.toml");
         let mut config_file = File::create(config_file_path.deref()).expect("config file");
         config_file.write_all(b"a = 7").expect("write config file");
-        let mut conf = KompactConfig::default();
+        let mut conf = crate::test_support::test_kompact_config();
         conf.load_config_str(default_values)
             .load_config_file(config_file_path.to_path_buf());
         let system = conf.build().wait().expect("system");
@@ -1365,14 +1382,20 @@ mod tests {
     #[test]
     fn test_async_build_inside_futures_executor() -> () {
         futures::executor::block_on(async {
-            let system = KompactConfig::default().build().await.expect("system");
+            let system = crate::test_support::test_kompact_config()
+                .build()
+                .await
+                .expect("system");
             system.shutdown().await.expect("shutdown");
         });
     }
 
     #[test]
     fn test_system_spawn() -> () {
-        let system = KompactConfig::default().build().wait().expect("system");
+        let system = crate::test_support::test_kompact_config()
+            .build()
+            .wait()
+            .expect("system");
         let handle = system.spawn(async move { "test".to_string() });
         let res = futures::executor::block_on(handle).expect("result");
         assert_eq!(res, "test");

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -50,6 +50,13 @@ fn default_logger() -> Arc<KompactLogger> {
         .expect("Can't re-initialise global logger after it has been dropped!")
 }
 
+pub(crate) fn set_default_logger(logger: KompactLogger) {
+    DEFAULT_ROOT_LOGGER
+        .load_full()
+        .expect("Can't re-initialise global logger after it has been dropped!");
+    DEFAULT_ROOT_LOGGER.store(Some(Arc::new(logger)));
+}
+
 /// Removes the global default logger
 ///
 /// This causes the remaining messages to be flushed to the output.

--- a/core/src/test_support.rs
+++ b/core/src/test_support.rs
@@ -1,0 +1,167 @@
+//! Test support utilities for Kompact systems.
+//!
+//! These helpers route logging through libtest's captured output path, keeping
+//! successful test runs quiet while preserving logs for failing tests and
+//! `--nocapture` runs.
+
+use crate::{
+    KompactLogger,
+    runtime::{self, KompactConfig, KompactSystem},
+    utils::BlockingFutureExt,
+};
+use slog::{Drain, Logger, PushFnValue, o};
+use std::{
+    io::{self, Write},
+    sync::{Arc, OnceLock},
+};
+
+/// Installs a captured logger for the `log` facade.
+///
+/// Calling this function multiple times is harmless. It panics if another
+/// `log` facade logger has already been installed in this process.
+pub fn init_test_logger() {
+    static INIT: OnceLock<()> = OnceLock::new();
+
+    INIT.get_or_init(|| {
+        log::set_logger(&CAPTURED_LOGGER).expect("install captured test logger");
+        log::set_max_level(log::LevelFilter::Trace);
+        runtime::set_default_logger(build_captured_kompact_logger());
+    });
+}
+
+/// Creates a Kompact logger whose output is captured by libtest.
+///
+/// This also installs the matching `log` facade logger once for the test
+/// process.
+pub fn captured_kompact_logger() -> KompactLogger {
+    init_test_logger();
+    build_captured_kompact_logger()
+}
+
+fn build_captured_kompact_logger() -> KompactLogger {
+    let decorator = slog_term::PlainSyncDecorator::new(CapturedOutput::default());
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).chan_size(1024).build().fuse();
+    Logger::root_typed(
+        Arc::new(drain),
+        o!(
+            "location" => PushFnValue(|record: &slog::Record<'_>, serializer| {
+                serializer.emit(format_args!("{}:{}", record.file(), record.line()))
+            })
+        ),
+    )
+}
+
+/// Configures a Kompact system to use the captured test logger.
+///
+/// Returns the same config for chaining.
+pub fn configure_test_logger(config: &mut KompactConfig) -> &mut KompactConfig {
+    config.logger(captured_kompact_logger())
+}
+
+/// Builds a default Kompact config that uses the captured test logger.
+#[must_use]
+pub fn test_kompact_config() -> KompactConfig {
+    let mut config = KompactConfig::default();
+    configure_test_logger(&mut config);
+    config
+}
+
+/// Builds a default Kompact system that uses the captured test logger.
+///
+/// # Panics
+///
+/// Panics if the system cannot be built.
+pub fn build_test_kompact_system() -> KompactSystem {
+    test_kompact_config().build().wait().expect("system")
+}
+
+static CAPTURED_LOGGER: CapturedLogLogger = CapturedLogLogger;
+
+struct CapturedLogLogger;
+
+impl log::Log for CapturedLogLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Trace
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let location = match (record.file(), record.line()) {
+            (Some(file), Some(line)) => format!("{file}:{line}"),
+            (Some(file), None) => file.to_string(),
+            _ => record.target().to_string(),
+        };
+        println!("[{} {}] {}", record.level(), location, record.args());
+    }
+
+    fn flush(&self) {
+        let _ = io::stdout().flush();
+    }
+}
+
+/// Writer that routes slog output through libtest's captured stdout path.
+#[derive(Default)]
+struct CapturedOutput {
+    pending: Vec<u8>,
+}
+
+impl CapturedOutput {
+    fn emit_complete_lines(&mut self) {
+        while let Some(newline_index) = self.pending.iter().position(|byte| *byte == b'\n') {
+            let line: Vec<u8> = self.pending.drain(..=newline_index).collect();
+            Self::emit_bytes(&line);
+        }
+    }
+
+    fn emit_bytes(bytes: &[u8]) {
+        let text = String::from_utf8_lossy(bytes);
+        print!("{text}");
+        let _ = io::stdout().flush();
+    }
+}
+
+impl Write for CapturedOutput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(buf);
+        self.emit_complete_lines();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.pending.is_empty() {
+            let remaining = std::mem::take(&mut self.pending);
+            Self::emit_bytes(&remaining);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CapturedOutput {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CapturedOutput;
+    use std::io::Write;
+
+    #[test]
+    fn captured_output_buffers_partial_lines() {
+        let mut output = CapturedOutput::default();
+
+        output.write_all(b"partial").expect("write partial line");
+        assert_eq!(output.pending, b"partial");
+
+        output.write_all(b" line\nnext").expect("write full line");
+        assert_eq!(output.pending, b"next");
+
+        output.flush().expect("flush pending line");
+        assert!(output.pending.is_empty());
+    }
+}

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -3,6 +3,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub use kompact::test_support::build_test_kompact_system as build_test_system;
+
 /// Wait until `predicate` returns true or panic after `timeout`.
 pub fn eventually(name: &str, timeout: Duration, predicate: impl Fn() -> bool) {
     let deadline = Instant::now() + timeout;

--- a/core/tests/extra_component_tests.rs
+++ b/core/tests/extra_component_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "distributed")]
 
-use kompact::prelude::*;
+use kompact::{prelude::*, test_support::build_test_kompact_system};
 use std::time::Duration;
 
 const REPEAT: usize = 100;
@@ -84,7 +84,7 @@ impl Actor for SelfCaller {
 
 #[test]
 fn repeated_blocking_self_messages() {
-    let system = KompactConfig::default().build().wait().expect("system");
+    let system = build_test_kompact_system();
     let comp = system.create(SelfCaller::new);
     let reg_f = system.update_alias_registration(&comp, "TEST_ME");
     reg_f.wait_expect(Duration::from_millis(100), "initial registration");

--- a/core/tests/handler_result_tests.rs
+++ b/core/tests/handler_result_tests.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::eventually;
+use common::{build_test_system, eventually};
 use kompact::prelude::*;
 use std::{
     error::Error,
@@ -292,7 +292,7 @@ fn assert_outcome(
 }
 
 fn run_case(source: HandlerSource, kind: FaultKind) {
-    let system = KompactConfig::default().build().wait().expect("system");
+    let system = build_test_system();
     let (component, rx) = create_probe(&system, source, kind);
 
     if kind == FaultKind::Recoverable {

--- a/docs/examples/local/src/bin/actor_helloworld.rs
+++ b/docs/examples/local/src/bin/actor_helloworld.rs
@@ -42,6 +42,7 @@ mod tests {
 
     #[test]
     fn test_actor_helloworld() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/buncher_adaptive.rs
+++ b/docs/examples/local/src/bin/buncher_adaptive.rs
@@ -123,6 +123,7 @@ mod tests {
 
     #[test]
     fn test_buncher() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/buncher_config.rs
+++ b/docs/examples/local/src/bin/buncher_config.rs
@@ -139,6 +139,7 @@ mod tests {
 
     #[test]
     fn test_buncher() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/buncher_regular.rs
+++ b/docs/examples/local/src/bin/buncher_regular.rs
@@ -120,6 +120,7 @@ mod tests {
 
     #[test]
     fn test_buncher() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/counters.rs
+++ b/docs/examples/local/src/bin/counters.rs
@@ -122,6 +122,7 @@ mod tests {
 
     #[test]
     fn test_counters() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/counters_channel_pool.rs
+++ b/docs/examples/local/src/bin/counters_channel_pool.rs
@@ -116,6 +116,7 @@ mod tests {
 
     #[test]
     fn test_counters() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/counters_pool.rs
+++ b/docs/examples/local/src/bin/counters_pool.rs
@@ -115,6 +115,7 @@ mod tests {
 
     #[test]
     fn test_counters() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/helloworld.rs
+++ b/docs/examples/local/src/bin/helloworld.rs
@@ -43,6 +43,7 @@ mod tests {
 
     #[test]
     fn test_helloworld() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/logging.rs
+++ b/docs/examples/local/src/bin/logging.rs
@@ -35,6 +35,7 @@ mod tests {
 
     #[test]
     fn test_logging() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/logging_custom.rs
+++ b/docs/examples/local/src/bin/logging_custom.rs
@@ -63,6 +63,7 @@ mod tests {
 
     #[test]
     fn test_logging() {
+        kompact::test_support::init_test_logger();
         main();
         std::fs::remove_file(FILE_NAME).expect("remove log file");
     }

--- a/docs/examples/local/src/bin/unstable_counter.rs
+++ b/docs/examples/local/src/bin/unstable_counter.rs
@@ -144,6 +144,7 @@ mod tests {
 
     #[test]
     fn test_unstable_counter() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/local/src/bin/workers.rs
+++ b/docs/examples/local/src/bin/workers.rs
@@ -286,6 +286,7 @@ mod tests {
 
     #[test]
     fn test_workers() {
+        kompact::test_support::init_test_logger();
         run_task(3, 1000);
     }
 }

--- a/docs/examples/local/src/bin/workers_sender.rs
+++ b/docs/examples/local/src/bin/workers_sender.rs
@@ -266,6 +266,7 @@ mod tests {
 
     #[test]
     fn test_workers() {
+        kompact::test_support::init_test_logger();
         run_task(3, 1000);
     }
 }

--- a/docs/examples/net/src/bin/bootstrapping.rs
+++ b/docs/examples/net/src/bin/bootstrapping.rs
@@ -297,6 +297,7 @@ mod tests {
 
     #[test]
     fn test_bootstrapping() {
+        kompact::test_support::init_test_logger();
         let server_socket: SocketAddr = SERVER_SOCKET.parse().unwrap();
         let server_system = run_server(server_socket);
         let client_socket: SocketAddr = CLIENT_SOCKET.parse().unwrap();

--- a/docs/examples/net/src/bin/leader_election.rs
+++ b/docs/examples/net/src/bin/leader_election.rs
@@ -208,6 +208,7 @@ mod tests {
 
     #[test]
     fn test_omega() {
+        kompact::test_support::init_test_logger();
         run_systems(3);
     }
 }

--- a/docs/examples/net/src/bin/load_balancer.rs
+++ b/docs/examples/net/src/bin/load_balancer.rs
@@ -326,6 +326,7 @@ mod tests {
 
     #[test]
     fn test_load_balancer() {
+        kompact::test_support::init_test_logger();
         main();
     }
 }

--- a/docs/examples/net/src/bin/serialisation.rs
+++ b/docs/examples/net/src/bin/serialisation.rs
@@ -378,6 +378,7 @@ mod tests {
 
     #[test]
     fn test_bootstrapping_serialisation() {
+        kompact::test_support::init_test_logger();
         let server_socket: SocketAddr = SERVER_SOCKET.parse().unwrap();
         let server_system = run_server(server_socket);
         let client_socket: SocketAddr = CLIENT_SOCKET.parse().unwrap();

--- a/network/src/dispatcher.rs
+++ b/network/src/dispatcher.rs
@@ -1114,7 +1114,7 @@ mod tests {
         let conflicting_socket =
             std::net::TcpListener::bind("127.0.0.1:0").expect("temporary conflicting listener");
         let conflicting_addr = conflicting_socket.local_addr().expect("listener address");
-        let mut cfg = KompactConfig::default();
+        let mut cfg = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg.system_components(DeadletterBox::new, {
             let net_config = NetworkConfig::new(conflicting_addr);
@@ -1128,7 +1128,7 @@ mod tests {
 
     #[test]
     fn network_cleanup() {
-        let mut cfg = KompactConfig::default();
+        let mut cfg = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg.system_components(DeadletterBox::new, {
             let net_config =
@@ -1151,7 +1151,7 @@ mod tests {
             .wait()
             .expect("KompactSystem failed to shut down!");
         println!("System shut down.");
-        let mut cfg2 = KompactConfig::default();
+        let mut cfg2 = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg2.system_components(DeadletterBox::new, {
             let net_config =
@@ -1178,7 +1178,7 @@ mod tests {
     /// The retry should occur when system2 is building and should succeed after system1 is killed.
     #[test]
     fn network_cleanup_with_timeout() {
-        let mut cfg = KompactConfig::default();
+        let mut cfg = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg.system_components(DeadletterBox::new, {
             let net_config =
@@ -1209,7 +1209,7 @@ mod tests {
             })
             .ok();
 
-        let mut cfg2 = KompactConfig::default();
+        let mut cfg2 = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg2.system_components(DeadletterBox::new, {
             let net_config =
@@ -1234,7 +1234,7 @@ mod tests {
 
     #[test]
     fn test_system_path_timing() {
-        let mut cfg = KompactConfig::default();
+        let mut cfg = kompact::test_support::test_kompact_config();
         println!("Configuring network");
         cfg.system_components(DeadletterBox::new, NetworkConfig::default().build());
         println!("Starting KompactSystem");
@@ -1254,7 +1254,7 @@ mod tests {
     // After indirectly asserting that the queue was dropped we start up a new pinger, and assert that it succeeds.
     fn cleanup_bufferchunks_from_dead_actors() {
         let system1 = || {
-            let mut cfg = KompactConfig::default();
+            let mut cfg = kompact::test_support::test_kompact_config();
             cfg.system_components(
                 DeadletterBox::new,
                 NetworkConfig::new("127.0.0.1:0".parse().expect("Address should work")).build(),
@@ -1262,7 +1262,7 @@ mod tests {
             cfg.build().wait().expect("KompactSystem")
         };
         let system2 = |port| {
-            let mut cfg = KompactConfig::default();
+            let mut cfg = kompact::test_support::test_kompact_config();
             cfg.system_components(
                 DeadletterBox::new,
                 NetworkConfig::new(SocketAddr::new("127.0.0.1".parse().unwrap(), port)).build(),

--- a/network/src/transport/network_thread.rs
+++ b/network/src/transport/network_thread.rs
@@ -1277,7 +1277,7 @@ mod tests {
     fn setup_network_thread(
         network_config: &NetworkConfig,
     ) -> (NetworkThread, Sender<DispatchEvent>) {
-        let mut cfg = KompactConfig::default();
+        let mut cfg = kompact::test_support::test_kompact_config();
         cfg.system_components(DeadletterBox::new, network_config.clone().build());
         let system = cfg.build().wait().expect("KompactSystem");
 

--- a/network/tests/dispatch_integration_tests.rs
+++ b/network/tests/dispatch_integration_tests.rs
@@ -1,5 +1,6 @@
 use crossbeam_channel::Receiver as Rcv;
 use ipnet::IpNet;
+use kompact::test_support::configure_test_logger;
 use kompact_net::{NetworkStatus, NetworkStatusRequest, net_test_helpers::*, prelude::*};
 use std::{
     cell::Cell,
@@ -213,6 +214,7 @@ impl DerefMut for TestSystem {
 fn system_from_network_config(network_config: NetworkConfig) -> TestSystem {
     let slot = TestSystemSlot::acquire();
     let mut cfg = KompactConfig::default();
+    configure_test_logger(&mut cfg);
     cfg.system_components(DeadletterBox::new, network_config.build());
     let inner = cfg.build().wait().expect("KompactSystem");
     TestSystem { inner, _slot: slot }


### PR DESCRIPTION
## Summary

- Add reusable `kompact::test_support` helpers that route Kompact `slog` output and the `log` facade through libtest-captured stdout.
- Allow tests to replace the process default Kompact logger so default `KompactConfig` systems stay quiet in successful runs.
- Migrate core, network, local example, and network example tests to use captured logging while preserving normal example code paths.

Closes #225.

## Validation

The new test-support writer has unit coverage for partial-line buffering and flush behaviour. Existing core component/runtime tests exercise captured logging for default and custom configurations, existing network tests cover reuse from `kompact-net`, and the local and network example tests cover test initialisation around example entry points.